### PR TITLE
Updates usage of the sockets.io 4.x interfaces

### DIFF
--- a/server/game.coffee
+++ b/server/game.coffee
@@ -144,7 +144,7 @@ d.run () ->
 
 getConnectedSpectatorsDataForGamePlayer = (gameId,playerId)->
 	spectators = []
-	for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
+	for socketId,connected of io.sockets.adapter.rooms.get("spectate-#{gameId}")
 		socket = io.sockets.sockets.get(socketId)
 		if socket.playerId == playerId
 			spectators.push({
@@ -192,7 +192,7 @@ onGamePlayerJoin = (requestData) ->
 	playerLeaveGameIfNeeded(this)
 
 	# if this client already exists in this game, disconnect duplicate client
-	for socketId,connected of io.sockets.adapter.rooms[gameId]
+	for socketId,connected of io.sockets.adapter.rooms.get(gameId)
 		socket = io.sockets.sockets.get(socketId)
 		if socket? and socket.playerId == playerId
 			Logger.module("IO").error "[G:#{gameId}]", "join_game -> detected duplicate connection to #{gameId} GameSession for #{playerId.blue}. Disconnecting duplicate...".cyan
@@ -533,7 +533,7 @@ onGameDisconnect = () ->
 
 		try
 
-			clients_in_the_room = io.sockets.adapter.rooms[@.gameId]
+			clients_in_the_room = io.sockets.adapter.rooms.get(@.gameId)
 			for clientId,socket of clients_in_the_room
 				if socket.playerId == @.playerId
 					Logger.module("IO").error "onGameDisconnect:: looks like the player #{@.playerId} we are trying to disconnect is still in the game #{@.gameId} room. ABORTING".red
@@ -730,7 +730,7 @@ onDisconnectedPlayerTimeout = (gameId,playerId) ->
 
 	Logger.module("IO").debug "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: #{playerId} for game: #{gameId}"
 
-	clients_in_the_room = io.sockets.adapter.rooms[gameId]
+	clients_in_the_room = io.sockets.adapter.rooms.get(gameId)
 	for clientId,socket of clients_in_the_room
 		if socket.playerId == playerId
 			Logger.module("IO").error "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: looks like the player #{playerId} we are trying to dis-connect is still in the game #{gameId} room. ABORTING".red
@@ -919,7 +919,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 						# NOTE: we should be OK to contiue to use the eventData here since indices of all actions are the same becuase the delayed game sessions is running as non-authoriative
 
 					# send events over to spectators of current player
-					for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
+					for socketId,connected of io.sockets.adapter.rooms.get("spectate-#{gameId}")
 						Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to player's spectators"
 						socket = io.sockets.sockets.get(socketId)
 						if socket? and socket.playerId == eventData.step.playerId
@@ -950,7 +950,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 						# broadcast whatever's in the buffer to the opponent
 						_.each(opponentEventDataBuffer, (eventData) ->
 							Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to opponent's spectators"
-							for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
+							for socketId,connected of io.sockets.adapter.rooms.get("spectate-#{gameId}")
 								socket = io.sockets.sockets.get(socketId)
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -983,7 +983,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 			# only broadcast valid steps
 			if eventData.step? and eventData.step.timestamp? and eventData.step.action?
 				# send the step to the owner
-				for socketId,connected of io.sockets.adapter.rooms[gameId]
+				for socketId,connected of io.sockets.adapter.rooms.get(gameId)
 					socket = io.sockets.sockets.get(socketId)
 					if socket? and socket.playerId == eventData.step.playerId
 						eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -1011,7 +1011,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 
 						# broadcast whatever's in the buffer to the opponent
 						_.each(opponentEventDataBuffer, (eventData) ->
-							for socketId,connected of io.sockets.adapter.rooms[gameId]
+							for socketId,connected of io.sockets.adapter.rooms.get(gameId)
 								socket = io.sockets.sockets.get(socketId)
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -1022,7 +1022,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 						)
 		else if eventData.type == EVENTS.invalid_action
 			# send the invalid action notification to the owner
-			for socketId,connected of io.sockets.adapter.rooms[gameId]
+			for socketId,connected of io.sockets.adapter.rooms.get(gameId)
 				socket = io.sockets.sockets.get(socketId)
 				if socket? and socket.playerId == eventData.playerId
 					eventDataCopy = JSON.parse(JSON.stringify(eventData))

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -145,7 +145,7 @@ d.run () ->
 getConnectedSpectatorsDataForGamePlayer = (gameId,playerId)->
 	spectators = []
 	for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-		socket = io.sockets.connected[socketId]
+		socket = io.sockets.sockets[socketId]
 		if socket.playerId == playerId
 			spectators.push({
 				id:socket.spectatorId,
@@ -193,7 +193,7 @@ onGamePlayerJoin = (requestData) ->
 
 	# if this client already exists in this game, disconnect duplicate client
 	for socketId,connected of io.sockets.adapter.rooms[gameId]
-		socket = io.sockets.connected[socketId]
+		socket = io.sockets.sockets[socketId]
 		if socket? and socket.playerId == playerId
 			Logger.module("IO").error "[G:#{gameId}]", "join_game -> detected duplicate connection to #{gameId} GameSession for #{playerId.blue}. Disconnecting duplicate...".cyan
 			playerLeaveGameIfNeeded(socket, silent=true)
@@ -539,7 +539,7 @@ onGameDisconnect = () ->
 					Logger.module("IO").error "onGameDisconnect:: looks like the player #{@.playerId} we are trying to disconnect is still in the game #{@.gameId} room. ABORTING".red
 					return
 
-			for clientId,socket of io.sockets.connected
+			for clientId,socket of io.sockets.sockets
 				if socket.playerId == @.playerId and not socket.spectatorId
 					Logger.module("IO").error "onGameDisconnect:: looks like the player #{@.playerId} that allegedly disconnected is still alive and well.".red
 					return
@@ -736,7 +736,7 @@ onDisconnectedPlayerTimeout = (gameId,playerId) ->
 			Logger.module("IO").error "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: looks like the player #{playerId} we are trying to dis-connect is still in the game #{gameId} room. ABORTING".red
 			return
 
-	for clientId,socket of io.sockets.connected
+	for clientId,socket of io.sockets.sockets
 		if socket.playerId == playerId and not socket.spectatorId
 			Logger.module("IO").error "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: looks like the player #{playerId} we are trying to disconnect is still connected but not in the game #{gameId} room.".red
 			return
@@ -921,7 +921,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 					# send events over to spectators of current player
 					for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
 						Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to player's spectators"
-						socket = io.sockets.connected[socketId]
+						socket = io.sockets.sockets[socketId]
 						if socket? and socket.playerId == eventData.step.playerId
 							# scrub the action data. this should not be skipped since some actions include entire deck that needs to be scrubbed because we don't want spectators deck sniping
 							eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -951,7 +951,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 						_.each(opponentEventDataBuffer, (eventData) ->
 							Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to opponent's spectators"
 							for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-								socket = io.sockets.connected[socketId]
+								socket = io.sockets.sockets[socketId]
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from opponent's spectator perspective
@@ -984,7 +984,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 			if eventData.step? and eventData.step.timestamp? and eventData.step.action?
 				# send the step to the owner
 				for socketId,connected of io.sockets.adapter.rooms[gameId]
-					socket = io.sockets.connected[socketId]
+					socket = io.sockets.sockets[socketId]
 					if socket? and socket.playerId == eventData.step.playerId
 						eventDataCopy = JSON.parse(JSON.stringify(eventData))
 						# always scrub steps for sensitive data from player perspective
@@ -1012,7 +1012,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 						# broadcast whatever's in the buffer to the opponent
 						_.each(opponentEventDataBuffer, (eventData) ->
 							for socketId,connected of io.sockets.adapter.rooms[gameId]
-								socket = io.sockets.connected[socketId]
+								socket = io.sockets.sockets[socketId]
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from player perspective
@@ -1023,7 +1023,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 		else if eventData.type == EVENTS.invalid_action
 			# send the invalid action notification to the owner
 			for socketId,connected of io.sockets.adapter.rooms[gameId]
-				socket = io.sockets.connected[socketId]
+				socket = io.sockets.sockets[socketId]
 				if socket? and socket.playerId == eventData.playerId
 					eventDataCopy = JSON.parse(JSON.stringify(eventData))
 					socket.emit EVENTS.network_game_event, eventDataCopy

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -122,7 +122,7 @@ healthPing = io
 
 # run main io.sockets inside of the domain
 d.run () ->
-	io.sockets.on "authenticated", (socket) ->
+	io.sockets.on "connection", (socket) ->
 		# add the socket to the error domain
 		d.add(socket)
 

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -145,7 +145,7 @@ d.run () ->
 getConnectedSpectatorsDataForGamePlayer = (gameId,playerId)->
 	spectators = []
 	for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-		socket = io.sockets.sockets[socketId]
+		socket = io.sockets.sockets.get(socketId)
 		if socket.playerId == playerId
 			spectators.push({
 				id:socket.spectatorId,
@@ -193,7 +193,7 @@ onGamePlayerJoin = (requestData) ->
 
 	# if this client already exists in this game, disconnect duplicate client
 	for socketId,connected of io.sockets.adapter.rooms[gameId]
-		socket = io.sockets.sockets[socketId]
+		socket = io.sockets.sockets.get(socketId)
 		if socket? and socket.playerId == playerId
 			Logger.module("IO").error "[G:#{gameId}]", "join_game -> detected duplicate connection to #{gameId} GameSession for #{playerId.blue}. Disconnecting duplicate...".cyan
 			playerLeaveGameIfNeeded(socket, silent=true)
@@ -921,7 +921,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 					# send events over to spectators of current player
 					for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
 						Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to player's spectators"
-						socket = io.sockets.sockets[socketId]
+						socket = io.sockets.sockets.get(socketId)
 						if socket? and socket.playerId == eventData.step.playerId
 							# scrub the action data. this should not be skipped since some actions include entire deck that needs to be scrubbed because we don't want spectators deck sniping
 							eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -951,7 +951,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 						_.each(opponentEventDataBuffer, (eventData) ->
 							Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to opponent's spectators"
 							for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-								socket = io.sockets.sockets[socketId]
+								socket = io.sockets.sockets.get(socketId)
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from opponent's spectator perspective
@@ -984,7 +984,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 			if eventData.step? and eventData.step.timestamp? and eventData.step.action?
 				# send the step to the owner
 				for socketId,connected of io.sockets.adapter.rooms[gameId]
-					socket = io.sockets.sockets[socketId]
+					socket = io.sockets.sockets.get(socketId)
 					if socket? and socket.playerId == eventData.step.playerId
 						eventDataCopy = JSON.parse(JSON.stringify(eventData))
 						# always scrub steps for sensitive data from player perspective
@@ -1012,7 +1012,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 						# broadcast whatever's in the buffer to the opponent
 						_.each(opponentEventDataBuffer, (eventData) ->
 							for socketId,connected of io.sockets.adapter.rooms[gameId]
-								socket = io.sockets.sockets[socketId]
+								socket = io.sockets.sockets.get(socketId)
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from player perspective
@@ -1023,7 +1023,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 		else if eventData.type == EVENTS.invalid_action
 			# send the invalid action notification to the owner
 			for socketId,connected of io.sockets.adapter.rooms[gameId]
-				socket = io.sockets.sockets[socketId]
+				socket = io.sockets.sockets.get(socketId)
 				if socket? and socket.playerId == eventData.playerId
 					eventDataCopy = JSON.parse(JSON.stringify(eventData))
 					socket.emit EVENTS.network_game_event, eventDataCopy

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -137,7 +137,7 @@ io.sockets.on "connection", (socket) ->
 getConnectedSpectatorsDataForGamePlayer = (gameId,playerId)->
 	spectators = []
 	for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-		socket = io.sockets.connected[socketId]
+		socket = io.sockets.sockets[socketId]
 		if socket.playerId == playerId
 			spectators.push({
 				id:socket.spectatorId,
@@ -185,7 +185,7 @@ onGamePlayerJoin = (requestData) ->
 
 	# if this client already exists in this game, disconnect duplicate client
 	for socketId,connected of io.sockets.adapter.rooms[gameId]
-		socket = io.sockets.connected[socketId]
+		socket = io.sockets.sockets[socketId]
 		if socket? and socket.playerId == playerId
 			Logger.module("IO").log "[G:#{gameId}]", "join_game -> detected duplicate connection to #{gameId} GameSession for #{playerId.blue}. Disconnecting duplicate...".cyan
 			playerLeaveGameIfNeeded(socket, silent=true)
@@ -531,7 +531,7 @@ onGameDisconnect = () ->
 					Logger.module("IO").log "onGameDisconnect:: looks like the player #{@.playerId} we are trying to disconnect is still in the game #{@.gameId} room. ABORTING".red
 					return
 
-			for clientId,socket of io.sockets.connected
+			for clientId,socket of io.sockets.sockets
 				if socket.playerId == @.playerId and not socket.spectatorId
 					Logger.module("IO").log "onGameDisconnect:: looks like the player #{@.playerId} that allegedly disconnected is still alive and well.".red
 					return
@@ -727,7 +727,7 @@ onDisconnectedPlayerTimeout = (gameId,playerId) ->
 			Logger.module("IO").log "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: looks like the player #{playerId} we are trying to dis-connect is still in the game #{gameId} room. ABORTING".red
 			return
 
-	for clientId,socket of io.sockets.connected
+	for clientId,socket of io.sockets.sockets
 		if socket.playerId == playerId and not socket.spectatorId
 			Logger.module("IO").log "[G:#{gameId}]", "onDisconnectedPlayerTimeout:: looks like the player #{playerId} we are trying to disconnect is still connected but not in the game #{gameId} room.".red
 			return
@@ -917,7 +917,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 					# send events over to spectators of current player
 					for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
 						Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to player's spectators"
-						socket = io.sockets.connected[socketId]
+						socket = io.sockets.sockets[socketId]
 						if socket? and socket.playerId == eventData.step.playerId
 							# scrub the action data. this should not be skipped since some actions include entire deck that needs to be scrubbed because we don't want spectators deck sniping
 							eventDataCopy = JSON.parse(JSON.stringify(eventData))
@@ -946,7 +946,7 @@ flushSpectatorNetworkEventBuffer = (gameId) ->
 						_.each(opponentEventDataBuffer, (eventData) ->
 							Logger.module("IO").debug "[G:#{gameId}]", "flushSpectatorNetworkEventBuffer() -> transmitting step #{eventData.step?.index?.toString().yellow} with action #{eventData.step.action?.name} to opponent's spectators"
 							for socketId,connected of io.sockets.adapter.rooms["spectate-#{gameId}"]
-								socket = io.sockets.connected[socketId]
+								socket = io.sockets.sockets[socketId]
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from opponent's spectator perspective
@@ -979,7 +979,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 			if eventData.step? and eventData.step.timestamp? and eventData.step.action?
 				# send the step to the owner
 				for socketId,connected of io.sockets.adapter.rooms[gameId]
-					socket = io.sockets.connected[socketId]
+					socket = io.sockets.sockets[socketId]
 					if socket? and socket.playerId == eventData.step.playerId
 						eventDataCopy = JSON.parse(JSON.stringify(eventData))
 						# always scrub steps for sensitive data from player perspective
@@ -1007,7 +1007,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 						# broadcast whatever's in the buffer to the opponent
 						_.each(opponentEventDataBuffer, (eventData) ->
 							for socketId,connected of io.sockets.adapter.rooms[gameId]
-								socket = io.sockets.connected[socketId]
+								socket = io.sockets.sockets[socketId]
 								if socket? and socket.playerId != eventData.step.playerId
 									eventDataCopy = JSON.parse(JSON.stringify(eventData))
 									# always scrub steps for sensitive data from player perspective
@@ -1018,7 +1018,7 @@ emitGameEvent = (fromSocket,gameId,eventData)->
 		else if eventData.type == EVENTS.invalid_action
 			# send the invalid action notification to the owner
 			for socketId,connected of io.sockets.adapter.rooms[gameId]
-				socket = io.sockets.connected[socketId]
+				socket = io.sockets.sockets[socketId]
 				if socket? and socket.playerId == eventData.playerId
 					eventDataCopy = JSON.parse(JSON.stringify(eventData))
 					socket.emit EVENTS.network_game_event, eventDataCopy
@@ -1768,7 +1768,7 @@ ai_executeAction = (gameId, action) ->
 		step = new SDK.Step(games[gameId].session, action.getOwnerId())
 		step.setAction(action)
 		opponentPlayerId = games[gameId].ai.getOpponentPlayerId()
-		for clientId,socket of io.sockets.connected
+		for clientId,socket of io.sockets.sockets
 			if socket.playerId == opponentPlayerId and !socket.spectatorId
 				onGameEvent.call(socket, {
 					type: EVENTS.step


### PR DESCRIPTION
@marwanhilmi This gets local single player working!

Changes:
- Replaces `io.sockets.connected` with `io.sockets.sockets` (shorthand for default namespace)
- Replaces index access (i.e. `map[key]`) with getters (i.e. `map.get(key)`), since the Sockets and Rooms objects are now Maps in socket.io 4.x
- Replaces `for socket of room` with `room.forEach(socketHandlerFn)` for the Map interface

Fixes #22 