### PR TITLE
Resolves some high-severity Snyk vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "moment-duration-format": "1.3.0",
     "morgan": "^1.2.3",
     "node-uuid": "^1.4.1",
-    "nodemailer": "^1.3.0",
+    "nodemailer": "^6.4.16",
     "p-throttle": "^1.1.0",
     "p-whilst": "^1.0.0",
     "pg": "8.0.3",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "form-urlencoded": "^1.2.1",
     "gamecenter-identity-verifier": "^0.1.1",
     "glicko2": "^0.8.4",
-    "googleapis": "^16.1.0",
     "handlebars": "^3.0.8",
     "hbs": "^4.1.0",
     "helmet": "^0.5.3",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "handlebars": "^4.7.7",
     "hbs": "^4.1.0",
     "helmet": "^0.8.0",
-    "i18next": "^4.0.0",
+    "i18next": "^19.8.5",
     "i18next-browser-languagedetector": "^2.1.0",
     "i18next-xhr-backend": "^1.2.1",
     "isomorphic-fetch": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "glicko2": "^0.8.4",
     "handlebars": "^4.7.7",
     "hbs": "^4.1.0",
-    "helmet": "^0.5.3",
+    "helmet": "^0.8.0",
     "i18next": "^4.0.0",
     "i18next-browser-languagedetector": "^2.1.0",
     "i18next-xhr-backend": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "coffee-script": "1.8.0",
     "colors": "*",
     "compose-middleware": "^2.0.1",
-    "convict": "^0.4.2",
+    "convict": "^6.2.2",
     "cors": "^2.7.1",
     "debug": "^2.2.0",
     "enum": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-urlencoded": "^1.2.1",
     "gamecenter-identity-verifier": "^0.1.1",
     "glicko2": "^0.8.4",
-    "handlebars": "^3.0.8",
+    "handlebars": "^4.7.7",
     "hbs": "^4.1.0",
     "helmet": "^0.5.3",
     "i18next": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "enum": "^2.3.0",
     "escape-goat": "^1.3.0",
     "express": "^4.8.5",
-    "express-jwt": "3.3.0",
+    "express-jwt": "^5.0.0",
     "express-real-ip": "^1.0.0",
     "fb": "^2.0.0-alpha1",
     "firebase": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "enum": "^2.3.0",
     "escape-goat": "^1.3.0",
     "express": "^4.8.5",
-    "express-jwt": "^5.0.0",
+    "express-jwt": "^6.0.0",
     "express-real-ip": "^1.0.0",
     "fb": "^2.0.0-alpha1",
     "firebase": "2.0.3",

--- a/server/middleware/signed_in.coffee
+++ b/server/middleware/signed_in.coffee
@@ -12,7 +12,10 @@ Then ensure both an ID and maybe(EMAIL) are present in the JWT payload
 We can add additional checks to the JWT payload here
 ###
 module.exports = compose([
-	expressJwt({secret: config.get('firebase.legacyToken')}),
+	expressJwt({
+		algorithms: ["HS256"], # Will be passed to jsonwebtoken.verify().
+		secret: config.get('firebase.legacyToken')
+	}),
 	(req, res, next) ->
 		result = t.validate(req.user.d, validators.token)
 		if not result.isValid()

--- a/yarn.lock
+++ b/yarn.lock
@@ -7694,7 +7694,7 @@ handlebars-registrar@^1.5.2:
     mtil "^0.1.3"
     require-glob "^1.3.2"
 
-handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
+handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3, handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7705,16 +7705,6 @@ handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
     wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
-
-handlebars@^3.0.8:
-  version "3.0.8"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-3.0.8.tgz#4e6ce3650fe6c53c151d106dcff1c5a7ca79e164"
-  integrity sha512-frzSzoxbJZSB719r+lM3UFKrnHIY6VPY/j47+GNOHVnBHxO+r+Y/iDjozAbj1SztmmMpr2CcZY6rLeN5mqX8zA==
-  dependencies:
-    optimist "^0.6.1"
-    source-map "^0.1.40"
-  optionalDependencies:
-    uglify-js "^2.6"
 
 har-schema@^2.0.0:
   version "2.0.0"
@@ -10433,11 +10423,6 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.1.3, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
-minimist@~0.0.1:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
-  integrity sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8=
-
 minimize@^1.5.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/minimize/-/minimize-1.8.1.tgz#a3674ade93f28a75ffa23b8e0f365cdc23d69d8b"
@@ -11363,14 +11348,6 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-optimist@^0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
-  integrity sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optionator@^0.5.0:
   version "0.5.0"
@@ -14018,7 +13995,7 @@ source-map-url@^0.4.0:
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
   integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
-source-map@0.1.x, source-map@^0.1.39, source-map@^0.1.40, source-map@~0.1.33:
+source-map@0.1.x, source-map@^0.1.39, source-map@~0.1.33:
   version "0.1.43"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.1.43.tgz#c24bc146ca517c1471f5dacbe2571b2b7f9e3346"
   integrity sha512-VtCvB9SIQhk3aF6h+N85EaqIaBFIAfZ9Cu+NJHHVvc8BbEcnvDcFw6sqQ2dQrT6SlOrZq3tIvyD9+EGq/lJryQ==
@@ -15331,7 +15308,7 @@ uglify-es@^3.0.15, uglify-es@^3.0.27:
     commander "~2.13.0"
     source-map "~0.6.1"
 
-uglify-js@^2.6, uglify-js@^2.6.1:
+uglify-js@^2.6.1:
   version "2.8.29"
   resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-2.8.29.tgz#29c5733148057bb4e1f75df35b7a9cb72e6a59dd"
   integrity sha512-qLq/4y2pjcU3vhlhseXGGJ7VbFO4pBANu0kwl8VCa9KEI0V8VfZIx2Fy3w01iSTA/pGwKZSmu/+I4etLNDdt5w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -599,11 +599,6 @@ JSONStream@^1.0.3, JSONStream@^1.0.4:
     jsonparse "^1.2.0"
     through ">=2.2.7 <3"
 
-"JSV@>= 4.0.x":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/JSV/-/JSV-4.0.2.tgz#d077f6825571f82132f9dffaed587b4029feff57"
-  integrity sha1-0Hf2glVx+CEy+d/67Vh7QCn+/1c=
-
 abbrev@1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.1.1.tgz#f8f2c887ad10bf67f634f005b6987fed3179aac8"
@@ -826,11 +821,6 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
     color-convert "^2.0.1"
-
-ansi-styles@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-1.0.0.tgz#cb102df1c56f5123eab8b67cd7b98027a0279178"
-  integrity sha1-yxAt8cVvUSPquLZ817mAJ6AnkXg=
 
 ansi-wrap@0.1.0, ansi-wrap@^0.1.0:
   version "0.1.0"
@@ -2825,15 +2815,6 @@ chalk@^4.0.0, chalk@^4.1.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-0.4.0.tgz#5199a3ddcd0c1efe23bc08c1b027b06176e0c64f"
-  integrity sha1-UZmj3c0MHv4jvAjBsCewYXbgxk8=
-  dependencies:
-    ansi-styles "~1.0.0"
-    has-color "~0.1.0"
-    strip-ansi "~0.1.0"
-
 change-case@2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/change-case/-/change-case-2.3.0.tgz#3d7c04e89dfe8119831ebf859c9e39558235a855"
@@ -2924,13 +2905,6 @@ cipher-base@^1.0.0, cipher-base@^1.0.1, cipher-base@^1.0.3:
   dependencies:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
-
-cjson@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/cjson/-/cjson-0.3.0.tgz#e6439b90703d312ff6e2224097bea92ce3d02a14"
-  integrity sha1-5kObkHA9MS/24iJAl76pLOPQKhQ=
-  dependencies:
-    jsonlint "1.6.0"
 
 clap@^1.0.9:
   version "1.2.3"
@@ -3629,15 +3603,13 @@ convert-source-map@~1.1.0:
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.1.3.tgz#4829c877e9fe49b3161f3bf3673888e204699860"
   integrity sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=
 
-convict@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/convict/-/convict-0.4.3.tgz#cf7149e6412525d2a2e9991ba6e7ecf4b8372891"
-  integrity sha1-z3FJ5kElJdKi6Zkbpufs9Lg3KJE=
+convict@^6.2.2:
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/convict/-/convict-6.2.3.tgz#61f02858f6f1c5806d55837c5bb54ed64731ee8a"
+  integrity sha512-mTY04Qr7WrqiXifdeUYXr4/+Te4hPFWDvz6J2FVIKCLc2XBhq63VOSSYAKJ+unhZAYOAjmEdNswTOeHt7s++pQ==
   dependencies:
-    cjson "0.3.0"
-    moment "2.6.0"
-    optimist "0.6.0"
-    validator "1.5.1"
+    lodash.clonedeep "^4.5.0"
+    yargs-parser "^20.2.7"
 
 cookie-signature@1.0.6:
   version "1.0.6"
@@ -7824,11 +7796,6 @@ has-bigints@^1.0.2:
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
   integrity sha512-tSvCKtBr9lkF0Ex0aQiP9N+OpV4zi2r/Nee5VkRDbaqv35RLYMzbwQfFSZZH0kR+Rd6302UJZ2p/bJCEoR3VoQ==
 
-has-color@~0.1.0:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/has-color/-/has-color-0.1.7.tgz#67144a5260c34fc3cca677d041daf52fe7b78b2f"
-  integrity sha1-ZxRKUmDDT8PMpnfQQdr1L+e3iy8=
-
 has-cors@1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/has-cors/-/has-cors-1.1.0.tgz#5e474793f7ea9843d1bb99c23eef49ff126fff39"
@@ -9360,14 +9327,6 @@ jsonify@~0.0.0:
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
   integrity sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=
 
-jsonlint@1.6.0:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/jsonlint/-/jsonlint-1.6.0.tgz#88aa46bc289a7ac93bb46cae2d58a187a9bb494a"
-  integrity sha1-iKpGvCiaesk7tGyuLVihh6m7SUo=
-  dependencies:
-    JSV ">= 4.0.x"
-    nomnom ">= 1.5.x"
-
 jsonparse@^1.2.0:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -10708,11 +10667,6 @@ moment-duration-format@1.3.0:
   resolved "https://registry.yarnpkg.com/moment-duration-format/-/moment-duration-format-1.3.0.tgz#541771b5f87a049cc65540475d3ad966737d6908"
   integrity sha1-VBdxtfh6BJzGVUBHXTrZZnN9aQg=
 
-moment@2.6.0:
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/moment/-/moment-2.6.0.tgz#0765b72b841dd213fa91914c0f6765122719f061"
-  integrity sha1-B2W3K4Qd0hP6kZFMD2dlEicZ8GE=
-
 moment@2.8.3:
   version "2.8.3"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.8.3.tgz#a01427bf8910f014fc4baa1b8d96f17f7e3f29a2"
@@ -11087,14 +11041,6 @@ nodemailer@^1.3.0:
     needle "^0.11.0"
     nodemailer-direct-transport "^1.1.0"
     nodemailer-smtp-transport "^1.1.0"
-
-"nomnom@>= 1.5.x":
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/nomnom/-/nomnom-1.8.1.tgz#2151f722472ba79e50a76fc125bb8c8f2e4dc2a7"
-  integrity sha1-IVH3Ikcrp55Qp2/BJbuMjy5Nwqc=
-  dependencies:
-    chalk "~0.4.0"
-    underscore "~1.6.0"
 
 nopt@3.x, nopt@^3.0.1:
   version "3.0.6"
@@ -11474,14 +11420,6 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
-
-optimist@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.0.tgz#69424826f3405f79f142e6fc3d9ae58d4dbb9200"
-  integrity sha1-aUJIJvNAX3nxQub8PZrljU27kgA=
-  dependencies:
-    minimist "~0.0.1"
-    wordwrap "~0.0.2"
 
 optimist@^0.6.1:
   version "0.6.1"
@@ -14609,11 +14547,6 @@ strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   dependencies:
     ansi-regex "^5.0.1"
 
-strip-ansi@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-0.1.1.tgz#39e8a98d044d150660abe4a6808acf70bb7bc991"
-  integrity sha1-OeipjQRNFQZgq+SmgIrPcLt7yZE=
-
 strip-bom-buf@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/strip-bom-buf/-/strip-bom-buf-1.0.0.tgz#1cb45aaf57530f4caf86c7f75179d2c9a51dd572"
@@ -15545,7 +15478,7 @@ underscore@*, underscore@>=1.3.1, underscore@>=1.7.0, underscore@^1.7.0, undersc
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.2.tgz#276cea1e8b9722a8dbed0100a407dda572125881"
   integrity sha512-ekY1NhRzq0B08g4bGuX4wd2jZx5GnKz6mKSqFL4nqBlfyMGiG10gDFhDTMEfYmDL6Jy0FUIZp7wiRB+0BP7J2g==
 
-"underscore@1.4.4 - 1.6.0", underscore@1.6.0, underscore@~1.6.0:
+"underscore@1.4.4 - 1.6.0", underscore@1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
   integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
@@ -15812,11 +15745,6 @@ validate-npm-package-license@^3.0.1:
   dependencies:
     spdx-correct "^3.0.0"
     spdx-expression-parse "^3.0.0"
-
-validator@1.5.1:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/validator/-/validator-1.5.1.tgz#7ab356cbbcbbb000ab85c43b8cda12621b1344c0"
-  integrity sha1-erNWy7y7sACrhcQ7jNoSYhsTRMA=
 
 validator@^3.18.0:
   version "3.43.0"
@@ -16409,7 +16337,7 @@ yargs-parser@^2.4.1:
     camelcase "^3.0.0"
     lodash.assign "^4.0.6"
 
-yargs-parser@^20.2.2:
+yargs-parser@^20.2.2, yargs-parser@^20.2.7:
   version "20.2.9"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-20.2.9.tgz#2eb7dc3b0289718fc295f362753845c41a0c94ee"
   integrity sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1233,13 +1233,6 @@ async@~1.0.0:
   resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
   integrity sha1-+PwEyjoTeErenhZBr5hXjPvWR6k=
 
-async@~2.1.4:
-  version "2.1.5"
-  resolved "https://registry.yarnpkg.com/async/-/async-2.1.5.tgz#e587c68580994ac67fc56ff86d3ac56bdbe810bc"
-  integrity sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=
-  dependencies:
-    lodash "^4.14.0"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
@@ -7104,16 +7097,6 @@ google-auth-library@^8.0.1:
     jws "^4.0.0"
     lru-cache "^6.0.0"
 
-google-auth-library@~0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/google-auth-library/-/google-auth-library-0.10.0.tgz#6e15babee85fd1dd14d8d128a295b6838d52136e"
-  integrity sha1-bhW6vuhf0d0U2NEoopW2g41SE24=
-  dependencies:
-    gtoken "^1.2.1"
-    jws "^3.1.4"
-    lodash.noop "^3.0.1"
-    request "^2.74.0"
-
 google-gax@^2.24.1:
   version "2.30.5"
   resolved "https://registry.yarnpkg.com/google-gax/-/google-gax-2.30.5.tgz#e836f984f3228900a8336f608c83d75f9cb73eff"
@@ -7133,13 +7116,6 @@ google-gax@^2.24.1:
     protobufjs "6.11.3"
     retry-request "^4.0.0"
 
-google-p12-pem@^0.1.0:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-0.1.2.tgz#33c46ab021aa734fa0332b3960a9a3ffcb2f3177"
-  integrity sha1-M8RqsCGqc0+gMys5YKmj/8svMXc=
-  dependencies:
-    node-forge "^0.7.1"
-
 google-p12-pem@^3.1.3:
   version "3.1.4"
   resolved "https://registry.yarnpkg.com/google-p12-pem/-/google-p12-pem-3.1.4.tgz#123f7b40da204de4ed1fbf2fd5be12c047fc8b3b"
@@ -7153,15 +7129,6 @@ google-p12-pem@^4.0.0:
   integrity sha512-lRTMn5ElBdDixv4a86bixejPSRk1boRtUowNepeKEVvYiFlkLuAJUVpEz6PfObDHYEKnZWq/9a2zC98xu62A9w==
   dependencies:
     node-forge "^1.3.1"
-
-googleapis@^16.1.0:
-  version "16.1.0"
-  resolved "https://registry.yarnpkg.com/googleapis/-/googleapis-16.1.0.tgz#0f19f2d70572d918881a0f626e3b1a2fa8629576"
-  integrity sha1-Dxny1wVy2RiIGg9ibjsaL6hilXY=
-  dependencies:
-    async "~2.1.4"
-    google-auth-library "~0.10.0"
-    string-template "~1.0.0"
 
 got@^5.0.0:
   version "5.7.1"
@@ -7275,16 +7242,6 @@ growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
-
-gtoken@^1.2.1:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/gtoken/-/gtoken-1.2.3.tgz#5509571b8afd4322e124cf66cf68115284c476d8"
-  integrity sha512-wQAJflfoqSgMWrSBk9Fg86q+sd6s7y6uJhIvvIPz++RElGlMtEqsdAR2oWwZ/WTEtp7P9xFbJRrT976oRgzJ/w==
-  dependencies:
-    google-p12-pem "^0.1.0"
-    jws "^3.0.0"
-    mime "^1.4.1"
-    request "^2.72.0"
 
 gtoken@^5.0.4:
   version "5.3.2"
@@ -9420,7 +9377,7 @@ jwks-rsa@^2.0.2:
     limiter "^1.1.5"
     lru-memoizer "^2.1.4"
 
-jws@^3.0.0, jws@^3.1.4, jws@^3.2.2:
+jws@^3.0.0, jws@^3.2.2:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/jws/-/jws-3.2.2.tgz#001099f3639468c9414000e99995fa52fb478304"
   integrity sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==
@@ -9850,11 +9807,6 @@ lodash.merge@^4.4.0, lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.noop@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/lodash.noop/-/lodash.noop-3.0.1.tgz#38188f4d650a3a474258439b96ec45b32617133c"
-  integrity sha1-OBiPTWUKOkdCWEObluxFsyYXEzw=
-
 lodash.once@^4.0.0:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/lodash.once/-/lodash.once-4.1.1.tgz#0dd3971213c7c56df880977d504c88fb471a97ac"
@@ -9918,7 +9870,7 @@ lodash@^3.3.1, lodash@^3.6.0, lodash@^3.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
-lodash@^4.0.0, lodash@^4.14.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.8.2:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.8.2:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -10928,11 +10880,6 @@ node-fetch@^2.6.1, node-fetch@^2.6.7:
   integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
   dependencies:
     whatwg-url "^5.0.0"
-
-node-forge@^0.7.1:
-  version "0.7.6"
-  resolved "https://registry.yarnpkg.com/node-forge/-/node-forge-0.7.6.tgz#fdf3b418aee1f94f0ef642cd63486c77ca9724ac"
-  integrity sha512-sol30LUpz1jQFBjOKwbjxijiE3b6pjd74YwfD0fJOKPjF+fONKb2Yg8rYgS6+bK6VDl+/wfr4IYpC7jDzLUIfw==
 
 node-forge@^1.3.1:
   version "1.3.1"
@@ -13291,7 +13238,7 @@ replacestream@^4.0.0:
     object-assign "^4.0.1"
     readable-stream "^2.0.2"
 
-request@2.x, request@2.x.x, request@^2.40.0, request@^2.44.0, request@^2.45.0, request@^2.54.0, request@^2.72.0, request@^2.74.0, request@^2.81.0, request@^2.88.0:
+request@2.x, request@2.x.x, request@^2.40.0, request@^2.44.0, request@^2.45.0, request@^2.54.0, request@^2.72.0, request@^2.81.0, request@^2.88.0:
   version "2.88.2"
   resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
   integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
@@ -14400,11 +14347,6 @@ string-editor@^0.1.0:
   integrity sha1-9f8bWsSu16xsL7jeI20VUbIPYdA=
   dependencies:
     editor "^1.0.0"
-
-string-template@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/string-template/-/string-template-1.0.0.tgz#9e9f2233dc00f218718ec379a28a5673ecca8b96"
-  integrity sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=
 
 string-width@^1.0.1, string-width@^1.0.2:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,10 +1218,10 @@ async-settle@^1.0.0:
   dependencies:
     async-done "^1.2.2"
 
-async@1.x, async@^1.5.2, async@~1.5.2:
+async@1.x, async@^1.5.0, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
-  integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
+  integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
 
 async@^0.9.0, async@~0.9.0:
   version "0.9.2"
@@ -5560,15 +5560,15 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express-jwt@3.3.0:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-3.3.0.tgz#d10e17244225b1968d20137ff77fc7488c88f494"
-  integrity sha1-0Q4XJEIlsZaNIBN/93/HSIyI9JQ=
+express-jwt@^5.0.0:
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-5.3.3.tgz#e557b4a63dd34c5ddd6ad81452738386314cc243"
+  integrity sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==
   dependencies:
-    async "^0.9.0"
+    async "^1.5.0"
     express-unless "^0.3.0"
-    jsonwebtoken "^5.0.0"
-    lodash "~3.10.1"
+    jsonwebtoken "^8.1.0"
+    lodash.set "^4.0.0"
 
 express-real-ip@^1.0.0:
   version "1.0.0"
@@ -9340,7 +9340,7 @@ jsonwebtoken@5.4.1:
     jws "^3.0.0"
     ms "^0.7.1"
 
-jsonwebtoken@8.5.1, jsonwebtoken@^8.5.1:
+jsonwebtoken@8.5.1, jsonwebtoken@^8.1.0, jsonwebtoken@^8.5.1:
   version "8.5.1"
   resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz#00e71e0b8df54c2121a1f26137df2280673bcc0d"
   integrity sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==
@@ -9355,15 +9355,6 @@ jsonwebtoken@8.5.1, jsonwebtoken@^8.5.1:
     lodash.once "^4.0.0"
     ms "^2.1.1"
     semver "^5.6.0"
-
-jsonwebtoken@^5.0.0:
-  version "5.7.0"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz#1c90f9a86ce5b748f5f979c12b70402b4afcddb4"
-  integrity sha1-HJD5qGzlt0j1+XnBK3BAK0r83bQ=
-  dependencies:
-    jws "^3.0.0"
-    ms "^0.7.1"
-    xtend "^4.0.1"
 
 jsprim@^1.2.2:
   version "1.4.2"
@@ -9874,6 +9865,11 @@ lodash.restparam@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
+lodash.set@^4.0.0:
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
+  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
+
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
@@ -9917,7 +9913,7 @@ lodash@2.4.1:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
   integrity sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=
 
-lodash@^3.3.1, lodash@^3.6.0, lodash@^3.7.0, lodash@~3.10.1:
+lodash@^3.3.1, lodash@^3.6.0, lodash@^3.7.0:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1105,6 +1105,11 @@ array.prototype.flat@^1.2.5:
     es-abstract "^1.19.2"
     es-shim-unscopables "^1.0.0"
 
+arraywrap@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/arraywrap/-/arraywrap-0.1.0.tgz#4da54e682ed4504fe5f467c9fb5be89c961f5430"
+  integrity sha512-5pH0POvxGlT4BfhOwGBmMRSo/Clcst4ve1SnRZXmkCk27dA0cqm/sKCVvMf2aa3HCX45ODj7CdJpnRjYz4jYGQ==
+
 arrify@^1.0.0, arrify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
@@ -3360,13 +3365,13 @@ confusing-browser-globals@^1.0.10:
   resolved "https://registry.yarnpkg.com/confusing-browser-globals/-/confusing-browser-globals-1.0.11.tgz#ae40e9b57cdd3915408a2805ebd3a5585608dc81"
   integrity sha512-JsPKdmh8ZkmnHxDk55FZ1TqVLvEQTvoByJZRN9jzI0UjxK/QgAmsphz7PGtqgPieQZ/CQcHWXCR7ATDNhGe+YA==
 
-connect@3.3.3:
-  version "3.3.3"
-  resolved "https://registry.yarnpkg.com/connect/-/connect-3.3.3.tgz#4b37b2cbb27a36e6ae18c9e7d3252ee6260c5941"
-  integrity sha1-Szeyy7J6NuauGMnn0yUu5iYMWUE=
+connect@3.3.5:
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/connect/-/connect-3.3.5.tgz#d1d9958c90a830bb429271e7a0a4aaaa9d033cab"
+  integrity sha512-CEFUIHTJ3joqSU0uN/WPlxoDl71SYpNvraM16I20uAWnjal10xBm6jk3NIJnfoGuXuhZMxiOOSqFYu0PbvRFxw==
   dependencies:
-    debug "~2.1.0"
-    finalhandler "0.3.2"
+    debug "~2.1.3"
+    finalhandler "0.3.4"
     parseurl "~1.3.0"
     utils-merge "1.0.0"
 
@@ -3630,6 +3635,11 @@ core-js@^2.0.0, core-js@^2.4.0, core-js@^2.5.0:
   version "2.6.12"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
   integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
+core-util-is@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.1.tgz#6b07085aef9a3ccac6ee53bf9d3df0c1521a5538"
+  integrity sha512-fyj6blBb339ReZvm1g6NHGVI/q7THT6UJb1GVDMVxRvGb2v9J1xazqnfQ10wrChRH6tpxJLY/eUmFH0+gANIRA==
 
 core-util-is@1.0.2:
   version "1.0.2"
@@ -3909,10 +3919,10 @@ debug@~1.0.1:
   dependencies:
     ms "2.0.0"
 
-debug@~2.1.0:
+debug@~2.1.3:
   version "2.1.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.1.3.tgz#ce8ab1b5ee8fbee2bfa3b633cab93d366b63418e"
-  integrity sha1-zoqxte6PvuK/o7Yzyrk9NmtjQY4=
+  integrity sha512-KWau3VQmxO3YwQCjJzMPPusOtI0hx3UGsqnY7RS+QHQjUeawpOVtJvAdeTrI2Ja5DTR8KH3xaEN8c+ADbXJWeg==
   dependencies:
     ms "0.7.0"
 
@@ -4219,6 +4229,11 @@ delegates@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delegates/-/delegates-1.0.0.tgz#84c6e159b81904fdca59a0ef44cd870d31250f9a"
   integrity sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
+depd@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-1.0.1.tgz#80aec64c9d6d97e65cc2a9caa93c0aa6abf73aaa"
+  integrity sha512-OEWAMbCkK9IWQ8pfTvHBhCSqHgR+sk5pbiYqq0FqfARG4Cy+cRsCbITx6wh5pcsmfBPiJAcbd98tfdz5fnBbag==
 
 depd@2.0.0, depd@~2.0.0:
   version "2.0.0"
@@ -5946,14 +5961,14 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
-finalhandler@0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-0.3.2.tgz#7b389b0fd3647a6f90bd564e22624bf8a4a77fb5"
-  integrity sha1-ezibD9Nkem+QvVZOImJL+KSnf7U=
+finalhandler@0.3.4:
+  version "0.3.4"
+  resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-0.3.4.tgz#4787d3573d079ae8b07536f26b0b911ebaf2a2ac"
+  integrity sha512-fg2FhK0sQAeb3EcYej2OPhczPIqmMGDHi8C+Ri3UPgslMJnmvwVkw6hFW3xUDt4aQowDwZd+BXGBTHDzMWYDyw==
   dependencies:
-    debug "~2.1.0"
+    debug "~2.1.3"
     escape-html "1.0.1"
-    on-finished "~2.1.1"
+    on-finished "~2.2.0"
 
 finalhandler@~1.1.2:
   version "1.1.2"
@@ -6225,12 +6240,12 @@ fragment-cache@^0.2.1:
   dependencies:
     map-cache "^0.2.2"
 
-frameguard@0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-0.2.0.tgz#f1b275c50bb6718a71c3fb48a5ffa820726b4adc"
-  integrity sha1-8bJ1xQu2cYpxw/tIpf+oIHJrStw=
+frameguard@0.2.2:
+  version "0.2.2"
+  resolved "https://registry.yarnpkg.com/frameguard/-/frameguard-0.2.2.tgz#0c897021c1444d7a0acc7b0318ca9238fe4cf06c"
+  integrity sha512-NCteWsSqtDrRb+oHIWjC6YqagO0y1BNI97yfrXR4ZMHfQDf5wMbjBQZqD+ZrMFHoLZEvf9/aSdclyUalXQiH8w==
   dependencies:
-    lodash.isstring "2.4.1"
+    lodash.isstring "3.0.1"
 
 fresh@0.5.2:
   version "0.5.2"
@@ -7879,30 +7894,32 @@ helmet-crossdomain@0.1.0:
   resolved "https://registry.yarnpkg.com/helmet-crossdomain/-/helmet-crossdomain-0.1.0.tgz#2774aa1e4475b00f78daa28d8215f9cdddcc8509"
   integrity sha1-J3SqHkR1sA942qKNghX5zd3MhQk=
 
-helmet-csp@0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-0.1.2.tgz#810d89f550af42167a51c79551141a1e44a92c22"
-  integrity sha1-gQ2J9VCvQhZ6UceVURQaHkSpLCI=
+helmet-csp@0.2.3:
+  version "0.2.3"
+  resolved "https://registry.yarnpkg.com/helmet-csp/-/helmet-csp-0.2.3.tgz#fedcaee3b404912187b0d9536e371a80fa16d2a8"
+  integrity sha512-UBJkLSCulyccFCd8E2hfmu9cA7fePWqupc70pRcDNyaiO6YIGWFmdZzHWTziSTDB31L/DKgP0nzhkesPnEozyA==
   dependencies:
     camelize "1.0.0"
-    lodash "2.4.1"
-    platform "1.2.0"
+    core-util-is "1.0.1"
+    platform "1.3.0"
 
-helmet@^0.5.3:
-  version "0.5.4"
-  resolved "https://registry.yarnpkg.com/helmet/-/helmet-0.5.4.tgz#59b84a7dce1bf3366ef0a1cbb1f5aecc5eac89d3"
-  integrity sha1-WbhKfc4b8zZu8KHLsfWuzF6sidM=
+helmet@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/helmet/-/helmet-0.8.0.tgz#a6c12e9e6f80611329a3b4af34fd075ebdaea7fe"
+  integrity sha512-EJL3ZbU6EOZfEWMvCVevZQ95xbD6V9yJYYw4S7uO1wk7CR3e36JOnhWLTR7jLwnktwTHXUhPWkuOSamzlSf0Sg==
   dependencies:
-    connect "3.3.3"
+    connect "3.3.5"
+    depd "1.0.1"
     dont-sniff-mimetype "0.1.0"
-    frameguard "0.2.0"
+    frameguard "0.2.2"
     helmet-crossdomain "0.1.0"
-    helmet-csp "0.1.2"
+    helmet-csp "0.2.3"
     hide-powered-by "0.1.0"
-    hsts "0.1.0"
+    hpkp "0.1.0"
+    hsts "0.1.2"
     ienoopen "0.1.0"
     nocache "0.2.0"
-    x-xss-protection "0.1.1"
+    x-xss-protection "0.1.2"
 
 hide-powered-by@0.1.0:
   version "0.1.0"
@@ -7938,12 +7955,19 @@ hosted-git-info@^2.1.4:
   resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
   integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
-hsts@0.1.0:
+hpkp@0.1.0:
   version "0.1.0"
-  resolved "https://registry.yarnpkg.com/hsts/-/hsts-0.1.0.tgz#0869ab8886767ec7fa7a107cb311554babbf700a"
-  integrity sha1-CGmriIZ2fsf6ehB8sxFVS6u/cAo=
+  resolved "https://registry.yarnpkg.com/hpkp/-/hpkp-0.1.0.tgz#b612a7bb9928e88ab10261e858291d99bb9c4fec"
+  integrity sha512-F6M+vofk/B4+lTwvCTNgMiS4kBzvAbmbLkcB40FKZMyGyuQ6mh0PO86Vs0BNNOVnvFQebBaoSj/vzmXrczSpyQ==
   dependencies:
-    underscore "1.7.0"
+    arraywrap "^0.1.0"
+
+hsts@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/hsts/-/hsts-0.1.2.tgz#56e3422703f64264b106aeb6817496dcf71ba4fa"
+  integrity sha512-1WfM1m4GdWjFTL1CVVajXdt1o2+56JEQ6tcL32irPya9+RbAVGKwmsJN1eXVezzldRNSATknYQPqIwqcQEcieQ==
+  dependencies:
+    core-util-is "1.0.1"
 
 html-comment-regex@^1.1.0:
   version "1.1.2"
@@ -9733,10 +9757,10 @@ lodash.isplainobject@^4.0.6:
   resolved "https://registry.yarnpkg.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz#7c526a52d89b45c45cc690b88163be0497f550cb"
   integrity sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs=
 
-lodash.isstring@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-2.4.1.tgz#3a4a42ee344b5bc09aeaa87ef1dc3097789d0792"
-  integrity sha1-OkpC7jRLW8Ca6qh+8dwwl3idB5I=
+lodash.isstring@3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/lodash.isstring/-/lodash.isstring-3.0.1.tgz#41638944ea042ef67ad67c293aa541d3f3d6e53c"
+  integrity sha512-UiX/KDS9ryxRpGR1q6zSwV9LxsG6PbN3OCD73O48JiRfG1z0cG3LCl3X9AEEdluRNuxduz1u94rS6BW9vSl9Vw==
 
 lodash.isstring@^4.0.1:
   version "4.0.1"
@@ -9814,11 +9838,6 @@ lodash.templatesettings@^4.0.0:
   integrity sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==
   dependencies:
     lodash._reinterpolate "^3.0.0"
-
-lodash@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-2.4.1.tgz#5b7723034dda4d262e5a46fb2c58d7cc22f71420"
-  integrity sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA=
 
 lodash@^3.3.1, lodash@^3.6.0, lodash@^3.7.0:
   version "3.10.1"
@@ -11202,10 +11221,10 @@ on-finished@2.4.1:
   dependencies:
     ee-first "1.1.1"
 
-on-finished@~2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.1.1.tgz#f82ca1c9e3a4f3286b1b9938610e5b8636bd3cb2"
-  integrity sha1-+CyhyeOk8yhrG5k4YQ5bhja9PLI=
+on-finished@~2.2.0:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/on-finished/-/on-finished-2.2.1.tgz#5c85c1cc36299f78029653f667f27b6b99ebc029"
+  integrity sha512-9HvMYLv7im5uzOAcg1lon2cEUxycCF4OI+zPz1R/x3MvBv5s2F+DuxrGwkPe+UwvStDQpWbrkXfLZv12mHbl4A==
   dependencies:
     ee-first "1.1.0"
 
@@ -11951,11 +11970,6 @@ pkginfo@>=0.2.3:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
   integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
-
-platform@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/platform/-/platform-1.2.0.tgz#5fade0d35757adc98d5b4f4b9d2c1f1e13ac04b0"
-  integrity sha1-X63g01dXrcmNW09LnSwfHhOsBLA=
 
 platform@1.3.0:
   version "1.3.0"
@@ -15307,11 +15321,6 @@ underscore@*, underscore@>=1.3.1, underscore@>=1.7.0, underscore@^1.7.0, undersc
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.6.0.tgz#8b38b10cacdef63337b8b24e4ff86d45aea529a8"
   integrity sha1-izixDKze9jM3uLJOT/htRa6lKag=
 
-underscore@1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.7.0.tgz#6bbaf0877500d36be34ecaa584e0db9fef035209"
-  integrity sha1-a7rwh3UA02vjTsqlhODbn+8DUgk=
-
 "underscore@>=1.3.3 <=1.8.3", "underscore@>=1.4.0 <=1.8.3":
   version "1.8.3"
   resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
@@ -16027,12 +16036,10 @@ ws@~8.2.3:
   resolved "https://registry.yarnpkg.com/ws/-/ws-8.2.3.tgz#63a56456db1b04367d0b721a0b80cae6d8becbba"
   integrity sha512-wBuoj1BDpC6ZQ1B7DWQBYVLphPWkm8i9Y0/3YdHjHKHiohOJ1ws+3OccDWtH+PoC9DZD5WOTrJvNbWvjS6JWaA==
 
-x-xss-protection@0.1.1:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-0.1.1.tgz#0a85cb13c21575cd7fa596f973a8d1e0cb6e55e6"
-  integrity sha1-CoXLE8IVdc1/pZb5c6jR4MtuVeY=
-  dependencies:
-    platform "1.3.0"
+x-xss-protection@0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/x-xss-protection/-/x-xss-protection-0.1.2.tgz#4ab3197e66ae133588eff8fcbc9f4347b8d02c73"
+  integrity sha512-Vj9iQCUkgTDSLvES4BEgXzZKzgVrsjI8U/ct59uGQHHLGNQCnW2ufwv6maP5AsGG54eUMw2qhEyM9q03cHJJAg==
 
 xml-nodes@^0.1.5:
   version "0.1.5"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,7 +1218,7 @@ async-settle@^1.0.0:
   dependencies:
     async-done "^1.2.2"
 
-async@1.x, async@^1.5.0, async@^1.5.2, async@~1.5.2:
+async@1.x, async@^1.5.2, async@~1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha512-nSVgobk4rv61R9PUSDtYt7mPVB2olxNR5RWJcAsH676/ef11bUZwvu7+RGYrYauVdDPcO519v68wRhXQtxsV9w==
@@ -1227,6 +1227,11 @@ async@^0.9.0, async@~0.9.0:
   version "0.9.2"
   resolved "https://registry.yarnpkg.com/async/-/async-0.9.2.tgz#aea74d5e61c1f899613bf64bda66d4c78f2fd17d"
   integrity sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=
+
+async@^3.2.2:
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/async/-/async-3.2.4.tgz#2d22e00f8cddeb5fde5dd33522b56d1cf569a81c"
+  integrity sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==
 
 async@~1.0.0:
   version "1.0.0"
@@ -5552,25 +5557,25 @@ expand-tilde@^2.0.0, expand-tilde@^2.0.2:
   dependencies:
     homedir-polyfill "^1.0.1"
 
-express-jwt@^5.0.0:
-  version "5.3.3"
-  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-5.3.3.tgz#e557b4a63dd34c5ddd6ad81452738386314cc243"
-  integrity sha512-UdB8p5O8vGYTKm3SfREnLgVGIGEHcL3lrVyi3ebEX2qhMuagN623ju7ywWis+qYL+CXE7G1qPc2bCPBAg2MxZQ==
+express-jwt@^6.0.0:
+  version "6.1.2"
+  resolved "https://registry.yarnpkg.com/express-jwt/-/express-jwt-6.1.2.tgz#4a6cc11d1dcff6f23126dd79ec5b2b441333e78b"
+  integrity sha512-l5dlf5lNM/1EODMsJGfHn1VnrhhsUYEetzrKFStJZLjFQXtR+HGdBiW+jUNZ+ISsFe+h7Wl/hQKjLrY2TX0Qkg==
   dependencies:
-    async "^1.5.0"
-    express-unless "^0.3.0"
+    async "^3.2.2"
+    express-unless "^1.0.0"
     jsonwebtoken "^8.1.0"
-    lodash.set "^4.0.0"
+    lodash "^4.17.21"
 
 express-real-ip@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/express-real-ip/-/express-real-ip-1.0.0.tgz#eb7b06b20a953b7b98707c8ff618e7f7bc86a01e"
   integrity sha1-63sGsgqVO3uYcHyP9hjn97yGoB4=
 
-express-unless@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-0.3.1.tgz#2557c146e75beb903e2d247f9b5ba01452696e20"
-  integrity sha1-JVfBRudb65A+LSR/m1ugFFJpbiA=
+express-unless@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/express-unless/-/express-unless-1.0.0.tgz#ecd1c354c5ccf7709a8a17ece617934e037cccd8"
+  integrity sha512-zXSSClWBPfcSYjg0hcQNompkFN/MxQQ53eyrzm9BYgik2ut2I7PxAf2foVqBRMYCwWaZx/aWodi+uk76npdSAw==
 
 express@^4.12.2, express@^4.8.5:
   version "4.17.3"
@@ -9796,11 +9801,6 @@ lodash.restparam@^3.0.0:
   resolved "https://registry.yarnpkg.com/lodash.restparam/-/lodash.restparam-3.6.1.tgz#936a4e309ef330a7645ed4145986c85ae5b20805"
   integrity sha1-k2pOMJ7zMKdkXtQUWYbIWuWyCAU=
 
-lodash.set@^4.0.0:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==
-
 lodash.template@^3.0.0:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/lodash.template/-/lodash.template-3.6.2.tgz#f8cdecc6169a255be9098ae8b0c53d378931d14f"
@@ -9844,7 +9844,7 @@ lodash@^3.3.1, lodash@^3.6.0, lodash@^3.7.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
   integrity sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y=
 
-lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.8.2:
+lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.15, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.2.1, lodash@^4.5.1, lodash@^4.8.2:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,6 +2,13 @@
 # yarn lockfile v1
 
 
+"@babel/runtime@^7.12.0":
+  version "7.19.0"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.19.0.tgz#22b11c037b094d27a8a2504ea4dcff00f50e2259"
+  integrity sha512-eR8Lo9hnDS7tqkO7NsV+mKvCmv5boaXFSZ70DnfhcgiEne8hv9oCEd36Klw74EtizEqLsy4YnW8UWwpBVolHZA==
+  dependencies:
+    regenerator-runtime "^0.13.4"
+
 "@bower_components/backbone.babysitter@marionettejs/backbone.babysitter#^0.1.0":
   version "0.1.12"
   resolved "https://codeload.github.com/marionettejs/backbone.babysitter/tar.gz/efd475f2e915775e790065b80d129f8a5b356c26"
@@ -8102,10 +8109,12 @@ i18next-xhr-backend@^1.2.1:
   resolved "https://registry.yarnpkg.com/i18next-xhr-backend/-/i18next-xhr-backend-1.5.1.tgz#50282610780c6a696d880dfa7f4ac1d01e8c3ad5"
   integrity sha512-9OLdC/9YxDvTFcgsH5t2BHCODHEotHCa6h7Ly0EUlUC7Y2GS09UeoHOGj3gWKQ3HCqXz8NlH4gOrK3NNc9vPuw==
 
-i18next@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-4.2.0.tgz#e0cbeea638c8dd8adc14137577c40fff00756963"
-  integrity sha1-4MvupjjI3YrcFBN1d8QP/wB1aWM=
+i18next@^19.8.5:
+  version "19.9.2"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-19.9.2.tgz#ea5a124416e3c5ab85fddca2c8e3c3669a8da397"
+  integrity sha512-0i6cuo6ER6usEOtKajUUDj92zlG+KArFia0857xxiEHAQcUwh/RtOQocui1LPJwunSYT574Pk64aNva1kwtxZg==
+  dependencies:
+    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.5:
   version "0.4.24"
@@ -12995,6 +13004,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.13.4:
+  version "0.13.9"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz#8925742a98ffd90814988d7566ad30ca3b263b52"
+  integrity sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA==
 
 regenerator-transform@^0.10.0:
   version "0.10.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -685,11 +685,6 @@ add-stream@^1.0.0:
   resolved "https://registry.yarnpkg.com/add-stream/-/add-stream-1.0.0.tgz#6a7990437ca736d5e1288db92bd3266d5f5cb2aa"
   integrity sha1-anmQQ3ynNtXhKI25K9MmbV9csqo=
 
-addressparser@^0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/addressparser/-/addressparser-0.3.2.tgz#59873f35e8fcf6c7361c10239261d76e15348bb2"
-  integrity sha1-WYc/Nej89sc2HBAjkmHXbhU0i7I=
-
 agent-base@6:
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
@@ -2537,17 +2532,6 @@ bugsnag@^1.8.0:
     request "^2.81.0"
     stack-trace "~0.0.9"
 
-buildmail@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/buildmail/-/buildmail-2.0.0.tgz#f0b7b0a59e9a4a1b5066bbfa051d248f3832eece"
-  integrity sha1-8LewpZ6aShtQZrv6BR0kjzgy7s4=
-  dependencies:
-    addressparser "^0.3.2"
-    libbase64 "^0.1.0"
-    libmime "^1.2.0"
-    libqp "^1.1.0"
-    needle "^0.10.0"
-
 builtin-status-codes@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz#85982878e21b98e1c66425e03d0174788f569ee8"
@@ -3897,7 +3881,7 @@ debug@*, debug@4, debug@4.3.4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^
   dependencies:
     ms "2.1.2"
 
-debug@2.6.9, debug@2.X, debug@^2.1.2, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.5.1, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
+debug@2.6.9, debug@2.X, debug@^2.1.3, debug@^2.2.0, debug@^2.3.3, debug@^2.5.1, debug@^2.6.3, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
   integrity sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
@@ -8094,7 +8078,7 @@ i18next@^4.0.0:
   resolved "https://registry.yarnpkg.com/i18next/-/i18next-4.2.0.tgz#e0cbeea638c8dd8adc14137577c40fff00756963"
   integrity sha1-4MvupjjI3YrcFBN1d8QP/wB1aWM=
 
-iconv-lite@0.4.24, iconv-lite@^0.4.13, iconv-lite@^0.4.4, iconv-lite@^0.4.5:
+iconv-lite@0.4.24, iconv-lite@^0.4.5:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -9559,25 +9543,6 @@ levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
-libbase64@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/libbase64/-/libbase64-0.1.0.tgz#62351a839563ac5ff5bd26f12f60e9830bb751e6"
-  integrity sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY=
-
-libmime@^1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/libmime/-/libmime-1.2.0.tgz#8d84b4f3b225b3704410236ef494906436ba742b"
-  integrity sha1-jYS087Ils3BEECNu9JSQZDa6dCs=
-  dependencies:
-    iconv-lite "^0.4.13"
-    libbase64 "^0.1.0"
-    libqp "^1.1.0"
-
-libqp@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/libqp/-/libqp-1.1.0.tgz#f5e6e06ad74b794fb5b5b66988bf728ef1dedbe8"
-  integrity sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g=
-
 liftoff@3.1.0, liftoff@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/liftoff/-/liftoff-3.1.0.tgz#c9ba6081f908670607ee79062d700df062c52ed3"
@@ -10035,14 +10000,6 @@ mailchimp@1.1.0:
   dependencies:
     qs "0.5.x"
     request "2.x.x"
-
-mailcomposer@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/mailcomposer/-/mailcomposer-2.1.0.tgz#a6531822899614fee899c92226d81e2b9cbb183d"
-  integrity sha1-plMYIomWFP7omckiJtgeK5y7GD0=
-  dependencies:
-    buildmail "^2.0.0"
-    libmime "^1.2.0"
 
 make-dir@^1.0.0, make-dir@^1.2.0:
   version "1.3.0"
@@ -10774,22 +10731,6 @@ ndjson@^1.3.0:
     split2 "^2.1.0"
     through2 "^2.0.3"
 
-needle@^0.10.0:
-  version "0.10.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-0.10.0.tgz#16a24d63f2a61152eb74cce1d12af85c507577d4"
-  integrity sha1-FqJNY/KmEVLrdMzh0Sr4XFB1d9Q=
-  dependencies:
-    debug "^2.1.2"
-    iconv-lite "^0.4.4"
-
-needle@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/needle/-/needle-0.11.0.tgz#02a71b008eaf7d55ae89fb9fd7685b7b88d7bc29"
-  integrity sha1-AqcbAI6vfVWuifuf12hbe4jXvCk=
-  dependencies:
-    debug "^2.1.2"
-    iconv-lite "^0.4.4"
-
 negotiator@0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.3.tgz#58e323a72fedc0d6f9cd4d31fe49f51479590ccd"
@@ -10938,37 +10879,10 @@ node.extend@^2.0.0:
     has "^1.0.3"
     is "^3.2.1"
 
-nodemailer-direct-transport@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nodemailer-direct-transport/-/nodemailer-direct-transport-1.1.0.tgz#a2f78708ee6f16ea0573fc82949d138ff172f624"
-  integrity sha1-oveHCO5vFuoFc/yClJ0Tj/Fy9iQ=
-  dependencies:
-    smtp-connection "^1.3.1"
-
-nodemailer-smtp-transport@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/nodemailer-smtp-transport/-/nodemailer-smtp-transport-1.1.0.tgz#e6c37f31885ab3080e7ded3cf528c4ad7e691398"
-  integrity sha1-5sN/MYhaswgOfe089SjErX5pE5g=
-  dependencies:
-    clone "^1.0.2"
-    nodemailer-wellknown "^0.1.7"
-    smtp-connection "^1.3.7"
-
-nodemailer-wellknown@^0.1.7:
-  version "0.1.10"
-  resolved "https://registry.yarnpkg.com/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz#586db8101db30cb4438eb546737a41aad0cf13d5"
-  integrity sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U=
-
-nodemailer@^1.3.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-1.11.0.tgz#4e69cb39b03015b1d1ef0c78a815412b9e976f79"
-  integrity sha1-TmnLObAwFbHR7wx4qBVBK56Xb3k=
-  dependencies:
-    libmime "^1.2.0"
-    mailcomposer "^2.1.0"
-    needle "^0.11.0"
-    nodemailer-direct-transport "^1.1.0"
-    nodemailer-smtp-transport "^1.1.0"
+nodemailer@^6.4.16:
+  version "6.7.8"
+  resolved "https://registry.yarnpkg.com/nodemailer/-/nodemailer-6.7.8.tgz#9f1af9911314960c0b889079e1754e8d9e3f740a"
+  integrity sha512-2zaTFGqZixVmTxpJRCFC+Vk5eGRd/fYtvIR+dl5u9QXLTQWGIf48x/JXvo58g9sa0bU6To04XUv554Paykum3g==
 
 nopt@3.x, nopt@^3.0.1:
   version "3.0.6"
@@ -13857,11 +13771,6 @@ slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
-
-smtp-connection@^1.3.1, smtp-connection@^1.3.7:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/smtp-connection/-/smtp-connection-1.3.8.tgz#55832c2160cfb3086e1dcd87fd1c19fa61b7f536"
-  integrity sha1-VYMsIWDPswhuHc2H/RwZ+mG39TY=
 
 snake-case@^1.1.0:
   version "1.1.2"


### PR DESCRIPTION
Upgrades another batch of dependencies to resolve more vulnerabilities reported by Snyk.

Testing done:
- Tests passing
- App builds succeed
- No new errors in browser console
- Services start successfully in Docker
- No new errors in backend services
- Was able to play through a practice game with no errors in frontend or backend

This does leave a few remaining "High" vulnerabilities which present some challenges:

- `moment.js` should be upgraded to `2.29.2` (https://security.snyk.io/vuln/SNYK-JS-MOMENT-2440688), but we have several date strings which don't satisfy RFC2822 or ISO formats (which raise errors in the new version). See http://momentjs.com/guides/#/warnings/js-date/ for more info.
- `pretty-error` has a vulnerability in dependency `ansi-regex` (https://security.snyk.io/vuln/SNYK-JS-ANSIREGEX-1583908), and a suitable upgrade version needs to be found.
- `pretty-error` has a vulnerability in dependency `nth-check` (https://security.snyk.io/vuln/SNYK-JS-NTHCHECK-1586032), and a suitable upgrade version needs to be found.
- `kue` has a vulnerability in dependency `pug` (https://security.snyk.io/vuln/SNYK-JS-PUG-1071616), but no upgrade version is available. We may be able to pin the version of `pug` separately.
- `pretty-ms` has a vulnerability in dependency `trim-newlines` (https://security.snyk.io/vuln/SNYK-JS-TRIMNEWLINES-1298042), and a suitable upgrade version needs to be found.
- `knex` has a vulnerability in dependency `unset-value` (https://security.snyk.io/vuln/SNYK-JS-UNSETVALUE-2400660), and a suitable upgrade version needs to be found.
- `@counterplay/warlock` has a vulnerability in dependency `extend` (https://security.snyk.io/vuln/npm:extend:20180424), but based on our usage the likelihood of this occurring is virtually zero.

Coincidentally, this also resolves the issue with logins requiring a refresh.

Closes #36



