### PR TITLE
Use Bootstrap CDN for FontAwesome fonts

### DIFF
--- a/app/ui/styles/fonts/fonts.scss
+++ b/app/ui/styles/fonts/fonts.scss
@@ -1,3 +1,6 @@
+// Use the Bootstrap CDN to serve FontAwesome fonts.
+$fa-font-path: '//netdna.bootstrapcdn.com/font-awesome/4.7.0/fonts';
+
 @import 'font-awesome/scss/font-awesome';
 @import 'opensans';
 @import 'lato';

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@bower_components/backbone.marionette": "marionettejs/backbone.marionette#2.2.2",
     "@bower_components/backbone.wreqr": "marionettejs/backbone.wreqr#^1.0.0",
     "@bower_components/backfire": "firebase/backfire#~0.4.0",
-    "@bower_components/bootstrap-sass-official": "twbs/bootstrap-sass#~3.2.0+1",
+    "@bower_components/bootstrap-sass-official": "twbs/bootstrap-sass#3.4.3",
     "@bower_components/firebase": "firebase/firebase-bower#2.0.x",
     "@bower_components/font-awesome": "FortAwesome/Font-Awesome#~4.2",
     "@bower_components/jquery": "components/jquery#~2.0.3",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "@bower_components/backfire": "firebase/backfire#~0.4.0",
     "@bower_components/bootstrap-sass-official": "twbs/bootstrap-sass#3.4.3",
     "@bower_components/firebase": "firebase/firebase-bower#2.0.x",
-    "@bower_components/font-awesome": "FortAwesome/Font-Awesome#~4.2",
+    "@bower_components/font-awesome": "FortAwesome/Font-Awesome#4.7.0",
     "@bower_components/jquery": "components/jquery#~2.0.3",
     "@bower_components/underscore": "jashkenas/underscore#1.6.0",
     "@bower_components/velocity": "julianshapiro/velocity#~1.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,9 +52,9 @@
   version "0.0.0"
   resolved "https://codeload.github.com/firebase/firebase-bower/tar.gz/e9b8b4f85de46362aa4af6556c1c3639e7ebe038"
 
-"@bower_components/font-awesome@FortAwesome/Font-Awesome#~4.2":
-  version "4.2.0"
-  resolved "https://codeload.github.com/FortAwesome/Font-Awesome/tar.gz/a65bd93d81e9e6bd5ebfa41757a4474960b973b4"
+"@bower_components/font-awesome@FortAwesome/Font-Awesome#4.7.0":
+  version "4.7.0"
+  resolved "https://codeload.github.com/FortAwesome/Font-Awesome/tar.gz/a8386aae19e200ddb0f6845b5feeee5eb7013687"
 
 "@bower_components/jquery@components/jquery#~2.0.3":
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,9 +44,9 @@
   dependencies:
     firebase "2.0.x"
 
-"@bower_components/bootstrap-sass-official@twbs/bootstrap-sass#~3.2.0+1":
-  version "3.2.0"
-  resolved "https://codeload.github.com/twbs/bootstrap-sass/tar.gz/a5f5954268779ce0faf7607b3c35191a8d0fdfe6"
+"@bower_components/bootstrap-sass-official@twbs/bootstrap-sass#3.4.3":
+  version "3.4.3"
+  resolved "https://codeload.github.com/twbs/bootstrap-sass/tar.gz/6b0ca5025c64f2e5696c8719cfce7148c78d0a50"
 
 "@bower_components/firebase@firebase/firebase-bower#2.0.x":
   version "0.0.0"


### PR DESCRIPTION
This is a regression caused in #21. The FontAwesome Bower component had been edited previously, but reinstalling dependencies with Yarn reverts the changes. Instead, we can set the `$fa-font-path` variable in `app/ui/styles/fonts/fonts.scss` to make this configuration resilient to Bower component changes.

Closes #37 