### PR TITLE
Fixes a localization typo and template rendering with Handlebars

### DIFF
--- a/app/ui/templates/item/tutorial/challenge_start.hbs
+++ b/app/ui/templates/item/tutorial/challenge_start.hbs
@@ -10,7 +10,7 @@
         <div class="challenge-name">The Challenge Begins!</div>
         <div class="challenge-difficulty">{{challenge.difficulty}}</div>
         <div class="challenge-description">{{challenge.otkChallengeStartMessage}}</div>
-        <button class="btn btn-clean btn-clean-secondary start">{{localize 'challenge.challenge_label_start'}}</button>
+        <button class="btn btn-clean btn-clean-secondary start">{{localize 'challenges.challenge_label_start'}}</button>
     </div>
     <div class="dialog-footer"></div>
 </div>

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "form-urlencoded": "^1.2.1",
     "gamecenter-identity-verifier": "^0.1.1",
     "glicko2": "^0.8.4",
-    "hbs": "^4.1.0",
+    "hbs": "4.1.0",
     "helmet": "^0.8.0",
     "i18next": "^19.8.5",
     "i18next-browser-languagedetector": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "form-urlencoded": "^1.2.1",
     "gamecenter-identity-verifier": "^0.1.1",
     "glicko2": "^0.8.4",
-    "handlebars": "^4.7.7",
     "hbs": "^4.1.0",
     "helmet": "^0.8.0",
     "i18next": "^19.8.5",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,24 @@
 {
   "name": "open-duelyst",
   "version": "1.0.0",
+  "engines": {
+    "yarn": ">= 1.0.0"
+  },
+  "resolutions": {
+    "handlebars": "4.5.3"
+  },
   "dependencies": {
+    "@bower_components/backbone": "jashkenas/backbone#1.1.2",
+    "@bower_components/backbone.babysitter": "marionettejs/backbone.babysitter#^0.1.0",
+    "@bower_components/backbone.marionette": "marionettejs/backbone.marionette#2.2.2",
+    "@bower_components/backbone.wreqr": "marionettejs/backbone.wreqr#^1.0.0",
+    "@bower_components/backfire": "firebase/backfire#~0.4.0",
+    "@bower_components/bootstrap-sass-official": "twbs/bootstrap-sass#3.4.3",
+    "@bower_components/firebase": "firebase/firebase-bower#2.0.x",
+    "@bower_components/font-awesome": "FortAwesome/Font-Awesome#4.7.0",
+    "@bower_components/jquery": "components/jquery#~2.0.3",
+    "@bower_components/underscore": "jashkenas/underscore#1.6.0",
+    "@bower_components/velocity": "julianshapiro/velocity#~1.2.0",
     "@counterplay/chromajs": "./packages/chroma-js",
     "@counterplay/exception-reporter": "./packages/exception-reporter",
     "@counterplay/warlock": "./packages/warlock",
@@ -74,18 +91,7 @@
     "validator": "^3.18.0",
     "web-animations-js": "2.1.3",
     "winston": "2.1.1",
-    "winston-papertrail": "1.0.1",
-    "@bower_components/backbone": "jashkenas/backbone#1.1.2",
-    "@bower_components/backbone.babysitter": "marionettejs/backbone.babysitter#^0.1.0",
-    "@bower_components/backbone.marionette": "marionettejs/backbone.marionette#2.2.2",
-    "@bower_components/backbone.wreqr": "marionettejs/backbone.wreqr#^1.0.0",
-    "@bower_components/backfire": "firebase/backfire#~0.4.0",
-    "@bower_components/bootstrap-sass-official": "twbs/bootstrap-sass#3.4.3",
-    "@bower_components/firebase": "firebase/firebase-bower#2.0.x",
-    "@bower_components/font-awesome": "FortAwesome/Font-Awesome#4.7.0",
-    "@bower_components/jquery": "components/jquery#~2.0.3",
-    "@bower_components/underscore": "jashkenas/underscore#1.6.0",
-    "@bower_components/velocity": "julianshapiro/velocity#~1.2.0"
+    "winston-papertrail": "1.0.1"
   },
   "devDependencies": {
     "@coffeelint/cli": "^5.2.9",
@@ -228,8 +234,5 @@
     "tsc": "tsc",
     "tsc:chroma-js": "tsc -p ./packages/chroma-js/tsconfig.json",
     "watch": "node --max_old_space_size=2048 --stack-size=100000 node_modules/gulp/bin/gulp.js build"
-  },
-  "engines": {
-    "yarn": ">= 1.0.0"
   }
 }

--- a/test/unit/misc/handlebars.js
+++ b/test/unit/misc/handlebars.js
@@ -1,0 +1,13 @@
+const Handlebars = require('handlebars');
+const { expect } = require('chai');
+
+class TestClass {}
+TestClass.prototype.accessMe = 'I am a prototype property';
+
+describe('Handlebars.UnitTests', () => {
+  it('should allow prototype property access', () => {
+    const template = Handlebars.compile('{{accessMe}}');
+    const result = template(new TestClass());
+    expect(result).to.eql('I am a prototype property');
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,7 +7709,18 @@ handlebars-registrar@^1.5.2:
     mtil "^0.1.3"
     require-glob "^1.3.2"
 
-handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
+handlebars@4.5.3:
+  version "4.5.3"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
+  integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
+  dependencies:
+    neo-async "^2.6.0"
+    optimist "^0.6.1"
+    source-map "^0.6.1"
+  optionalDependencies:
+    uglify-js "^3.1.4"
+
+handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -7884,13 +7895,13 @@ hasha@^2.2.0:
     is-stream "^1.0.1"
     pinkie-promise "^2.0.0"
 
-hbs@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/hbs/-/hbs-4.2.0.tgz#10e40dcc24d5be7342df9636316896617542a32b"
-  integrity sha512-dQwHnrfWlTk5PvG9+a45GYpg0VpX47ryKF8dULVd6DtwOE6TEcYQXQ5QM6nyOx/h7v3bvEQbdn19EDAcfUAgZg==
+hbs@4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/hbs/-/hbs-4.1.0.tgz#ddcf3d574a6be5f7abfbd8a350a3db62ef66a13c"
+  integrity sha512-YDrUBtLpwRl0H5uyCGLE2LGtGJl51VvJFBj/D+Cqyr6XMopCvwXA0ynRpd87u6aVIYCeGYZHESfZzPHbNMkOPA==
   dependencies:
-    handlebars "4.7.7"
-    walk "2.3.15"
+    handlebars "4.5.3"
+    walk "2.3.14"
 
 hbsfy@^2.7.0:
   version "2.8.1"
@@ -10412,6 +10423,11 @@ minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.1.3, minimist@^1.
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
+minimist@~0.0.1:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.10.tgz#de3f98543dbf96082be48ad1a0c7cda836301dcf"
+  integrity sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==
+
 minimize@^1.5.0:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/minimize/-/minimize-1.8.1.tgz#a3674ade93f28a75ffa23b8e0f365cdc23d69d8b"
@@ -11294,6 +11310,14 @@ open@^8.4.0:
     define-lazy-prop "^2.0.0"
     is-docker "^2.1.1"
     is-wsl "^2.2.0"
+
+optimist@^0.6.1:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/optimist/-/optimist-0.6.1.tgz#da3ea74686fa21a19a111c326e90eb15a0196686"
+  integrity sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==
+  dependencies:
+    minimist "~0.0.1"
+    wordwrap "~0.0.2"
 
 optionator@^0.5.0:
   version "0.5.0"
@@ -15797,10 +15821,10 @@ vorpal@^1.11.4:
     strip-ansi "^3.0.0"
     wrap-ansi "^2.0.0"
 
-walk@2.3.15:
-  version "2.3.15"
-  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.15.tgz#1b4611e959d656426bc521e2da5db3acecae2424"
-  integrity sha512-4eRTBZljBfIISK1Vnt69Gvr2w/wc3U6Vtrw7qiN5iqYJPH7LElcYh/iU4XWhdCy2dZqv1ToMyYlybDylfG/5Vg==
+walk@2.3.14:
+  version "2.3.14"
+  resolved "https://registry.yarnpkg.com/walk/-/walk-2.3.14.tgz#60ec8631cfd23276ae1e7363ce11d626452e1ef3"
+  integrity sha512-5skcWAUmySj6hkBdH6B6+3ddMjVQYH5Qy9QGbPmN8kVmLteXk+yVXg+yfk1nbX30EYakahLrr8iPcCxJQSCBeg==
   dependencies:
     foreachasync "^3.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,7 +7709,7 @@ handlebars-registrar@^1.5.2:
     mtil "^0.1.3"
     require-glob "^1.3.2"
 
-handlebars@4.5.3:
+handlebars@4.5.3, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
   version "4.5.3"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.5.3.tgz#5cf75bd8714f7605713511a56be7c349becb0482"
   integrity sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==
@@ -7717,18 +7717,6 @@ handlebars@4.5.3:
     neo-async "^2.6.0"
     optimist "^0.6.1"
     source-map "^0.6.1"
-  optionalDependencies:
-    uglify-js "^3.1.4"
-
-handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
-  version "4.7.7"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
-  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
-  dependencies:
-    minimist "^1.2.5"
-    neo-async "^2.6.0"
-    source-map "^0.6.1"
-    wordwrap "^1.0.0"
   optionalDependencies:
     uglify-js "^3.1.4"
 
@@ -10418,7 +10406,7 @@ minimist@0.0.8:
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
   integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.2, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,7 +7709,7 @@ handlebars-registrar@^1.5.2:
     mtil "^0.1.3"
     require-glob "^1.3.2"
 
-handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3, handlebars@^4.7.7:
+handlebars@4.7.7, handlebars@^4.0.1, handlebars@^4.0.2, handlebars@^4.0.3:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==


### PR DESCRIPTION
Resolves two issues:

1. There was a typo in the `challenges.challenge_label_start` localization key, which has been fixed.
2. The upgrade of `hbs` in #49 upgraded `handlebars` beyond version 4.5.3, after which prototype property and method access (which we use) is disallowed due to security concerns. However, since we don't accept user-provided Handlebars templates, this is not a concern for us. I've used Yarn's `resolutions` block in `package.json` to pin `handlebars` to version 4.5.3.

I've confirmed the fixes for these issues by creating a new account locally and completing the first tutorial. I've also added a new unit test for Handlebars prototype property access.

Closes #34