### PR TITLE
Adds more CloudWatch alarms for AWS infrastructure

### DIFF
--- a/server/game.coffee
+++ b/server/game.coffee
@@ -60,7 +60,7 @@ dnsHealthCheck = () ->
 server = http.createServer (req, res) ->
 	pathname = url.parse(req.url).pathname
 	if pathname == '/health'
-		Logger.module("GAME SERVER").debug "HTTP Health Ping"
+		#Logger.module("GAME SERVER").debug "HTTP Health Ping"
 		res.statusCode = 200
 		res.write JSON.stringify({players: playerCount, games: gameCount})
 		res.end()

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -61,7 +61,7 @@ dnsHealthCheck = () ->
 server = http.createServer (req, res) ->
 	pathname = url.parse(req.url).pathname
 	if pathname == '/health'
-		Logger.module("GAME SERVER").debug "HTTP Health Ping"
+		#Logger.module("GAME SERVER").debug "HTTP Health Ping"
 		res.statusCode = 200
 		res.write JSON.stringify({players: playerCount, games: gameCount})
 		res.end()

--- a/terraform/modules/alarms/billing/main.tf
+++ b/terraform/modules/alarms/billing/main.tf
@@ -1,7 +1,7 @@
 # NOTE: You must enable monitoring of estimated charges before creating alerts.
 # Docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html#turning_on_billing_metrics
 resource "aws_cloudwatch_metric_alarm" "alarm" {
-  alarm_name        = "estimated-billing"
+  alarm_name        = "Estimated monthly bill will exceed target threshold"
   alarm_description = "AWS bill is on track to exceed ${var.threshold} USD this month"
 
   namespace           = "AWS/Billing"

--- a/terraform/modules/alarms/billing/main.tf
+++ b/terraform/modules/alarms/billing/main.tf
@@ -2,13 +2,17 @@
 # Docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html#turning_on_billing_metrics
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   alarm_name        = "estimated-billing"
-  alarm_description = "AWS bill is on track to exceed $${var.threshold} this month!"
+  alarm_description = "AWS bill is on track to exceed ${var.threshold} this month!"
 
-  namespace           = "Billing"
+  namespace           = "AWS/Billing"
   metric_name         = "EstimatedCharges"
-  statistic           = "Average"
+  statistic           = "Maximum"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = var.threshold
+
+  dimensions = {
+    Currency = "USD"
+  }
 
   # Check the metric once per hour.
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation

--- a/terraform/modules/alarms/billing/main.tf
+++ b/terraform/modules/alarms/billing/main.tf
@@ -2,7 +2,7 @@
 # Docs: https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/monitor_estimated_charges_with_cloudwatch.html#turning_on_billing_metrics
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   alarm_name        = "estimated-billing"
-  alarm_description = "AWS bill is on track to exceed ${var.threshold} this month!"
+  alarm_description = "AWS bill is on track to exceed ${var.threshold} USD this month"
 
   namespace           = "AWS/Billing"
   metric_name         = "EstimatedCharges"

--- a/terraform/modules/alarms/billing/variables.tf
+++ b/terraform/modules/alarms/billing/variables.tf
@@ -1,5 +1,5 @@
 variable "threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when estimated monthly charges exceed this dollar amount."
 }
 

--- a/terraform/modules/alarms/data_transfer/main.tf
+++ b/terraform/modules/alarms/data_transfer/main.tf
@@ -3,6 +3,7 @@
 # $0.09/GB sent.
 # NOTE: Alarms targeting Standard metrics (not High-resolution metrics) are billed at $0.10/month. The first 10 alarms
 # in an AWS account are free, indefinitely.
+# NOTE: Aggregating metrics across dimensions (in this case InstanceId) is only available with Detailed Monitoring.
 resource "aws_cloudwatch_metric_alarm" "alarm" {
   alarm_name        = "ec2-data-transfer-free-tier"
   alarm_description = "EC2 Data Transfer is at 90% of Free Tier threshold!"
@@ -16,6 +17,10 @@ resource "aws_cloudwatch_metric_alarm" "alarm" {
   # Set the threshold to 80% of the limit, so we get the alarm before billing begins.
   # There are 730 hours in the average month. 100000000000 / 730 * 80% = 109589041.
   threshold = "109589041" # 109MB/hour in bytes. Proportional to 80GB/month.
+
+  dimensions = {
+    InstanceId = "*"
+  }
 
   # Check the metric once per hour.
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation

--- a/terraform/modules/alarms/ecs/main.tf
+++ b/terraform/modules/alarms/ecs/main.tf
@@ -1,0 +1,45 @@
+resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
+  alarm_name        = "ECS CPU Utilization"
+  alarm_description = "ECS CPU utilization is over ${var.cpu_threshold}"
+
+  namespace           = "AWS/ECS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.cpu_threshold
+
+  dimensions = {
+    ClusterName = var.cluster_name
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
+  alarm_name        = "ECS Memory Utilization"
+  alarm_description = "ECS memory utilization is over ${var.memory_threshold}"
+
+  namespace           = "AWS/ECS"
+  metric_name         = "MemoryUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.memory_threshold
+
+  dimensions = {
+    ClusterName = var.cluster_name
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}

--- a/terraform/modules/alarms/ecs/main.tf
+++ b/terraform/modules/alarms/ecs/main.tf
@@ -1,6 +1,6 @@
 resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
   alarm_name        = "ECS CPU Utilization"
-  alarm_description = "ECS CPU utilization is over ${var.cpu_threshold}"
+  alarm_description = "ECS CPU utilization is over ${var.cpu_threshold}%"
 
   namespace           = "AWS/ECS"
   metric_name         = "CPUUtilization"
@@ -23,7 +23,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
   alarm_name        = "ECS Memory Utilization"
-  alarm_description = "ECS memory utilization is over ${var.memory_threshold}"
+  alarm_description = "ECS memory utilization is over ${var.memory_threshold}%"
 
   namespace           = "AWS/ECS"
   metric_name         = "MemoryUtilization"

--- a/terraform/modules/alarms/ecs/main.tf
+++ b/terraform/modules/alarms/ecs/main.tf
@@ -43,3 +43,55 @@ resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
   alarm_actions             = var.alarm_actions
   insufficient_data_actions = []
 }
+
+resource "aws_cloudwatch_metric_alarm" "service_cpu_alarm" {
+  for_each = toset(var.service_names)
+
+  alarm_name        = "ECS Service CPU Utilization for ${each.key}"
+  alarm_description = "ECS service CPU utilization for ${each.key} is over ${var.cpu_threshold}%"
+
+  namespace           = "AWS/ECS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.cpu_threshold
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = each.key
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "service_memory_alarm" {
+  for_each = toset(var.service_names)
+
+  alarm_name        = "ECS Service Memory Utilization for ${each.key}"
+  alarm_description = "ECS service memory utilization for ${each.key} is over ${var.memory_threshold}%"
+
+  namespace           = "AWS/ECS"
+  metric_name         = "MemoryUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.memory_threshold
+
+  dimensions = {
+    ClusterName = var.cluster_name
+    ServiceName = each.key
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}

--- a/terraform/modules/alarms/ecs/variables.tf
+++ b/terraform/modules/alarms/ecs/variables.tf
@@ -1,27 +1,16 @@
-variable "cluster_id" {
+variable "cluster_name" {
   type        = string
-  description = "The Elasticache cluster to monitor."
+  description = "The ECS cluster to monitor."
 }
 
-variable "node_id" {
-  type        = string
-  description = "The Elasticache node to monitor."
-}
-
-variable "instance_type" {
-  type        = string
-  description = "The instance type of cache nodes."
+variable "service_names" {
+  type        = list(string)
+  description = "The ECS services to monitor."
 }
 
 variable "cpu_threshold" {
   type        = string
   description = "Fire an alert when CPU utilization exceeds this threshold (%)."
-  default     = 90
-}
-
-variable "engine_cpu_threshold" {
-  type        = string
-  description = "Fire an alert when engine CPU utilization exceeds this threshold (%)."
   default     = 90
 }
 

--- a/terraform/modules/alarms/ecs/variables.tf
+++ b/terraform/modules/alarms/ecs/variables.tf
@@ -9,13 +9,13 @@ variable "service_names" {
 }
 
 variable "cpu_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when CPU utilization exceeds this threshold (%)."
   default     = 90
 }
 
 variable "memory_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when memory utilization exceeds this threshold (%)."
   default     = 90
 }

--- a/terraform/modules/alarms/elasticache/main.tf
+++ b/terraform/modules/alarms/elasticache/main.tf
@@ -1,0 +1,77 @@
+locals {
+  memory_available = {
+    "cache.t3.micro" = 0.5 * 1000 * 1000 * 1000 # Bytes.
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
+  alarm_name        = "ElastiCache CPU Utilization"
+  alarm_description = "ElastiCache system CPU utilization is over ${var.cpu_threshold}"
+
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.cpu_threshold
+
+  dimensions = {
+    CacheClusterId = var.cluster_id
+    CacheNodeId    = var.node_id
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "engine_cpu_alarm" {
+  alarm_name        = "ElastiCache Engine CPU Utilization"
+  alarm_description = "ElastiCache engine CPU utilization is over ${var.engine_cpu_threshold}"
+
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "EngineCPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.engine_cpu_threshold
+
+  dimensions = {
+    CacheClusterId = var.cluster_id
+    CacheNodeId    = var.node_id
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
+  alarm_name        = "ElastiCache Memory Utilization"
+  alarm_description = "ElastiCache memory utilization is over ${var.memory_threshold}"
+
+  namespace           = "AWS/ElastiCache"
+  metric_name         = "BytesUsedForCache"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.memory_threshold * local.memory_available[var.instance_type] / 100
+
+  dimensions = {
+    CacheClusterId = var.cluster_id
+    CacheNodeId    = var.node_id
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}

--- a/terraform/modules/alarms/elasticache/main.tf
+++ b/terraform/modules/alarms/elasticache/main.tf
@@ -6,7 +6,7 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
   alarm_name        = "ElastiCache CPU Utilization"
-  alarm_description = "ElastiCache system CPU utilization is over ${var.cpu_threshold}"
+  alarm_description = "ElastiCache system CPU utilization is over ${var.cpu_threshold}%"
 
   namespace           = "AWS/ElastiCache"
   metric_name         = "CPUUtilization"
@@ -30,7 +30,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
 
 resource "aws_cloudwatch_metric_alarm" "engine_cpu_alarm" {
   alarm_name        = "ElastiCache Engine CPU Utilization"
-  alarm_description = "ElastiCache engine CPU utilization is over ${var.engine_cpu_threshold}"
+  alarm_description = "ElastiCache engine CPU utilization is over ${var.engine_cpu_threshold}%"
 
   namespace           = "AWS/ElastiCache"
   metric_name         = "EngineCPUUtilization"
@@ -54,7 +54,7 @@ resource "aws_cloudwatch_metric_alarm" "engine_cpu_alarm" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
   alarm_name        = "ElastiCache Memory Utilization"
-  alarm_description = "ElastiCache memory utilization is over ${var.memory_threshold}"
+  alarm_description = "ElastiCache memory utilization is over ${var.memory_threshold}%"
 
   namespace           = "AWS/ElastiCache"
   metric_name         = "BytesUsedForCache"

--- a/terraform/modules/alarms/elasticache/variables.tf
+++ b/terraform/modules/alarms/elasticache/variables.tf
@@ -1,0 +1,34 @@
+variable "cluster_id" {
+  type        = string
+  description = "The Elasticache cluster to monitor."
+}
+
+variable "node_id" {
+  type        = string
+  description = "The Elasticache node to monitor."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The instance type of cache nodes."
+}
+
+variable "cpu_threshold" {
+  type        = string
+  description = "Fire an alert when CPU utilization exceeds this threshold (%)."
+}
+
+variable "engine_cpu_threshold" {
+  type        = string
+  description = "Fire an alert when engine CPU utilization exceeds this threshold (%)."
+}
+
+variable "memory_threshold" {
+  type        = string
+  description = "Fire an alert when memory utilization exceeds this threshold (%)."
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "Actions to take when the alarm fires."
+}

--- a/terraform/modules/alarms/elasticache/variables.tf
+++ b/terraform/modules/alarms/elasticache/variables.tf
@@ -14,19 +14,19 @@ variable "instance_type" {
 }
 
 variable "cpu_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when CPU utilization exceeds this threshold (%)."
   default     = 90
 }
 
 variable "engine_cpu_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when engine CPU utilization exceeds this threshold (%)."
   default     = 90
 }
 
 variable "memory_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when memory utilization exceeds this threshold (%)."
   default     = 90
 }

--- a/terraform/modules/alarms/load_balancer/main.tf
+++ b/terraform/modules/alarms/load_balancer/main.tf
@@ -1,2 +1,51 @@
-# unhealthy target groups
-# 5xx rates
+resource "aws_cloudwatch_metric_alarm" "unhealthy_target_alarm" {
+  for_each = toset(var.target_group_ids)
+
+  alarm_name        = "Unhealthy targets in group ${each.key}"
+  alarm_description = "At least ${var.unhealthy_target_threshold} targets are unhealthy in target group ${each.key}."
+
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "UnHealthyHostCount"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.unhealthy_target_threshold
+
+  dimensions = {
+    LoadBalancer = var.load_balancer_id
+    TargetGroup  = each.key
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "error_rate_alarm" {
+  for_each = toset(var.target_group_ids)
+
+  alarm_name        = "Elevated 5xx for targets in group ${each.key}"
+  alarm_description = "Observed more than ${var.error_threshold} 5xx errors for target ${each.key} in window."
+
+  namespace           = "AWS/ApplicationELB"
+  metric_name         = "HTTPCode_Target_5XX_Count"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.error_threshold
+
+  dimensions = {
+    LoadBalancer = var.load_balancer_id
+    TargetGroup  = each.key
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}

--- a/terraform/modules/alarms/load_balancer/main.tf
+++ b/terraform/modules/alarms/load_balancer/main.tf
@@ -1,0 +1,2 @@
+# unhealthy target groups
+# 5xx rates

--- a/terraform/modules/alarms/load_balancer/variables.tf
+++ b/terraform/modules/alarms/load_balancer/variables.tf
@@ -1,0 +1,26 @@
+variable "load_balancer_id" {
+  type        = string
+  description = "The load balancer to monitor."
+}
+
+variable "target_group_ids" {
+  type        = list(string)
+  description = "The target groups to monitor."
+}
+
+variable "unhealthy_target_threshold" {
+  type        = number
+  description = "Fire an alert when this many targets are unhealthy."
+  default     = 1
+}
+
+variable "error_threshold" {
+  type        = number
+  description = "Fire an alert when this many errors are returned in 5 minutes."
+  default     = 10
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "Actions to take when the alarm fires."
+}

--- a/terraform/modules/alarms/rds/main.tf
+++ b/terraform/modules/alarms/rds/main.tf
@@ -1,0 +1,51 @@
+locals {
+  memory_available = {
+    "db.t4g.micro" = 1.0 * 1000 * 1000 * 1000 # Bytes.
+  }
+}
+
+resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
+  alarm_name        = "RDS CPU Utilization"
+  alarm_description = "RDS CPU utilization is over ${var.cpu_threshold}"
+
+  namespace           = "AWS/RDS"
+  metric_name         = "CPUUtilization"
+  statistic           = "Maximum"
+  comparison_operator = "GreaterThanOrEqualToThreshold"
+  threshold           = var.cpu_threshold
+
+  dimensions = {
+    DBInstanceIdentifier = var.database_id
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}
+
+resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
+  alarm_name        = "RDS Memory Utilization"
+  alarm_description = "RDS memory utilization is over ${var.memory_threshold}"
+
+  namespace           = "AWS/RDS"
+  metric_name         = "FreeableMemory"
+  statistic           = "Minimum"
+  comparison_operator = "LessThanOrEqualToThreshold"
+  threshold           = local.memory_available[var.instance_type] * (100 - var.memory_threshold) / 100
+
+  dimensions = {
+    DBInstanceIdentifier = var.database_id
+  }
+
+  # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
+  period              = "60" # The period in seconds over which the specified statistic is applied.
+  evaluation_periods  = 5    # The number of periods over which data is compared to the specified threshold.
+  datapoints_to_alarm = 3    # The number of datapoints that must be breaching to trigger the alarm.
+
+  alarm_actions             = var.alarm_actions
+  insufficient_data_actions = []
+}

--- a/terraform/modules/alarms/rds/main.tf
+++ b/terraform/modules/alarms/rds/main.tf
@@ -6,7 +6,7 @@ locals {
 
 resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
   alarm_name        = "RDS CPU Utilization"
-  alarm_description = "RDS CPU utilization is over ${var.cpu_threshold}"
+  alarm_description = "RDS CPU utilization is over ${var.cpu_threshold}%"
 
   namespace           = "AWS/RDS"
   metric_name         = "CPUUtilization"
@@ -29,7 +29,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
 
 resource "aws_cloudwatch_metric_alarm" "memory_alarm" {
   alarm_name        = "RDS Memory Utilization"
-  alarm_description = "RDS memory utilization is over ${var.memory_threshold}"
+  alarm_description = "RDS memory utilization is over ${var.memory_threshold}%"
 
   namespace           = "AWS/RDS"
   metric_name         = "FreeableMemory"

--- a/terraform/modules/alarms/rds/variables.tf
+++ b/terraform/modules/alarms/rds/variables.tf
@@ -1,0 +1,24 @@
+variable "database_id" {
+  type        = string
+  description = "The RDS node to monitor."
+}
+
+variable "instance_type" {
+  type        = string
+  description = "The instance type of database nodes."
+}
+
+variable "cpu_threshold" {
+  type        = string
+  description = "Fire an alert when CPU utilization exceeds this threshold (%)."
+}
+
+variable "memory_threshold" {
+  type        = string
+  description = "Fire an alert when memory utilization exceeds this threshold (%)."
+}
+
+variable "alarm_actions" {
+  type        = list(string)
+  description = "Actions to take when the alarm fires."
+}

--- a/terraform/modules/alarms/rds/variables.tf
+++ b/terraform/modules/alarms/rds/variables.tf
@@ -9,13 +9,13 @@ variable "instance_type" {
 }
 
 variable "cpu_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when CPU utilization exceeds this threshold (%)."
   default     = 90
 }
 
 variable "memory_threshold" {
-  type        = string
+  type        = number
   description = "Fire an alert when memory utilization exceeds this threshold (%)."
   default     = 90
 }

--- a/terraform/modules/alarms/rds/variables.tf
+++ b/terraform/modules/alarms/rds/variables.tf
@@ -11,11 +11,13 @@ variable "instance_type" {
 variable "cpu_threshold" {
   type        = string
   description = "Fire an alert when CPU utilization exceeds this threshold (%)."
+  default     = 90
 }
 
 variable "memory_threshold" {
   type        = string
   description = "Fire an alert when memory utilization exceeds this threshold (%)."
+  default     = 90
 }
 
 variable "alarm_actions" {

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -42,14 +42,14 @@ variable "container_count" {
 
 variable "container_cpu" {
   type        = number
-  description = "The number of vCPUs to allocate to each container."
-  default     = 1
+  description = "The number of CPU units to allocate to each container."
+  default     = 1000
 }
 
 variable "container_mem" {
   type        = number
   description = "The amount of memory to allocate to each container."
-  default     = 32
+  default     = 350 # Allows for 2 containers on a t4g.micro instance.
 }
 
 variable "enable_lb" {

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -5,3 +5,14 @@ output "api_target_group_arn" {
 output "sp_target_group_arn" {
   value = aws_lb_target_group.sp_target_group.arn
 }
+
+output "load_balancer_id" {
+  value = aws_lb.lb.arn_suffix
+}
+
+output "target_group_ids" {
+  value = [
+    aws_lb_target_group.api_target_group.arn_suffix,
+    aws_lb_target_group.sp_target_group.arn_suffix,
+  ]
+}

--- a/terraform/modules/postgres_db/outputs.tf
+++ b/terraform/modules/postgres_db/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_type" {
+  value = aws_db_instance.postgres.instance_class
+}

--- a/terraform/modules/redis_cache/outputs.tf
+++ b/terraform/modules/redis_cache/outputs.tf
@@ -1,3 +1,7 @@
 output "instance_dns" {
   value = aws_elasticache_cluster.redis.cache_nodes[0].address
 }
+
+output "instance_type" {
+  value = aws_elasticache_cluster.redis.node_type
+}

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -9,22 +9,24 @@ module "billing_alarm" {
   alarm_actions = [module.email_sns_topic.topic_arn]
 }
 
+module "ecs_alarms" {
+  source        = "../modules/alarms/ecs"
+  cluster_name  = "duelyst-staging"
+  service_names = []
+  alarm_actions = [module.email_sns_topic.topic_arn]
+}
+
 module "redis_alarms" {
-  source               = "../modules/alarms/elasticache"
-  cluster_id           = "duelyst-staging"
-  node_id              = "0001"
-  instance_type        = module.redis.instance_type
-  cpu_threshold        = 90
-  engine_cpu_threshold = 90
-  memory_threshold     = 90
-  alarm_actions        = [module.email_sns_topic.topic_arn]
+  source        = "../modules/alarms/elasticache"
+  cluster_id    = "duelyst-staging"
+  node_id       = "0001"
+  instance_type = module.redis.instance_type
+  alarm_actions = [module.email_sns_topic.topic_arn]
 }
 
 module "postgres_alarms" {
-  source           = "../modules/alarms/rds"
-  database_id      = "duelyst-staging"
-  instance_type    = module.postgres.instance_type
-  cpu_threshold    = 90
-  memory_threshold = 90
-  alarm_actions    = [module.email_sns_topic.topic_arn]
+  source        = "../modules/alarms/rds"
+  database_id   = "duelyst-staging"
+  instance_type = module.postgres.instance_type
+  alarm_actions = [module.email_sns_topic.topic_arn]
 }

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -3,11 +3,6 @@ module "email_sns_topic" {
   email_address = var.email_address_for_alarms
 }
 
-module "data_transfer_alarm" {
-  source        = "../modules/alarms/data_transfer"
-  alarm_actions = [module.email_sns_topic.topic_arn]
-}
-
 module "billing_alarm" {
   source        = "../modules/alarms/billing"
   threshold     = var.billing_alarm_threshold

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -9,9 +9,16 @@ module "billing_alarm" {
   alarm_actions = [module.email_sns_topic.topic_arn]
 }
 
+module "lb_alarms" {
+  source           = "../modules/alarms/load_balancer"
+  load_balancer_id = module.staging_load_balancer.load_balancer_id
+  target_group_ids = module.staging_load_balancer.target_group_ids
+  alarm_actions    = [module.email_sns_topic.topic_arn]
+}
+
 module "ecs_alarms" {
-  source        = "../modules/alarms/ecs"
-  cluster_name  = "duelyst-staging"
+  source       = "../modules/alarms/ecs"
+  cluster_name = "duelyst-staging"
   service_names = [
     "duelyst-api-staging",
     "duelyst-sp-staging",

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -8,3 +8,14 @@ module "billing_alarm" {
   threshold     = var.billing_alarm_threshold
   alarm_actions = [module.email_sns_topic.topic_arn]
 }
+
+module "redis_alarms" {
+  source               = "../modules/alarms/elasticache"
+  cluster_id           = "duelyst-staging"
+  node_id              = "0001"
+  instance_type        = module.redis.instance_type
+  cpu_threshold        = 90
+  engine_cpu_threshold = 90
+  memory_threshold     = 90
+  alarm_actions        = [module.email_sns_topic.topic_arn]
+}

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -19,3 +19,12 @@ module "redis_alarms" {
   memory_threshold     = 90
   alarm_actions        = [module.email_sns_topic.topic_arn]
 }
+
+module "postgres_alarms" {
+  source           = "../modules/alarms/rds"
+  database_id      = "duelyst-staging"
+  instance_type    = module.postgres.instance_type
+  cpu_threshold    = 90
+  memory_threshold = 90
+  alarm_actions    = [module.email_sns_topic.topic_arn]
+}

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -12,7 +12,10 @@ module "billing_alarm" {
 module "ecs_alarms" {
   source        = "../modules/alarms/ecs"
   cluster_name  = "duelyst-staging"
-  service_names = []
+  service_names = [
+    "duelyst-api-staging",
+    "duelyst-sp-staging",
+  ]
   alarm_actions = [module.email_sns_topic.topic_arn]
 }
 

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -22,8 +22,6 @@ module "ecs_service_api" {
   ecr_repository    = module.ecr_repository_api.id
   deployed_version  = "1.97.0"
   container_count   = 1
-  container_cpu     = 1
-  container_mem     = 350 # "1GB" instances are actually 936MB; system uses 158MB.
   service_port      = 3000
   alb_target_group  = module.staging_load_balancer.api_target_group_arn
 
@@ -54,8 +52,6 @@ module "ecs_service_sp" {
   ecr_repository    = module.ecr_repository_sp.id
   deployed_version  = "1.97.0"
   container_count   = 1
-  container_cpu     = 1
-  container_mem     = 350 # "1GB" instances are actually 936MB; system uses 158MB.
   service_port      = 8000
   alb_target_group  = module.staging_load_balancer.sp_target_group_arn
 


### PR DESCRIPTION
## Summary

Adds more CloudWatch alarms for AWS infrastructure.


Server Changes (`config/`, `server/`, `worker/`, etc.):

- Disables log spam from Game/SP health checks

Infrastructure Changes (`terraform/`, etc.):

- Fixes billing alarm
- Disables data transfer alarm (requires detailed monitoring)
- Adds RDS, ElastiCache, ALB, ECS cluster, and ECS service alarms
- Fixes CPU units on ECS tasks (1 vCPU is 1000 units)

## Testing

I have tested my changes in the following scenarios:

- [ ] Building the app with `yarn build` succeeds.
- [ ] Starting backend services locally with `docker compose up` succeeds.
- [ ] I am able to log in and complete a practice game locally.

^ All N/A.