### PR TITLE
Provisions the Game and Worker services in staging

### DIFF
--- a/docker/game.Dockerfile
+++ b/docker/game.Dockerfile
@@ -1,0 +1,7 @@
+# Build on top of the prebuilt Node.js image for OpenDuelyst.
+ARG NODEJS_IMAGE_VERSION
+FROM duelyst-nodejs:${NODEJS_IMAGE_VERSION}
+
+# Start the service.
+EXPOSE 8001
+ENTRYPOINT ["yarn", "game"]

--- a/docker/worker.Dockerfile
+++ b/docker/worker.Dockerfile
@@ -1,0 +1,6 @@
+# Build on top of the prebuilt Node.js image for OpenDuelyst.
+ARG NODEJS_IMAGE_VERSION
+FROM duelyst-nodejs:${NODEJS_IMAGE_VERSION}
+
+# Start the service.
+ENTRYPOINT ["yarn", "worker"]

--- a/terraform/modules/alarms/load_balancer/main.tf
+++ b/terraform/modules/alarms/load_balancer/main.tf
@@ -1,5 +1,5 @@
 resource "aws_cloudwatch_metric_alarm" "unhealthy_target_alarm" {
-  for_each = toset(var.target_group_ids)
+  for_each = var.target_group_ids
 
   alarm_name        = "Unhealthy targets in group ${each.key}"
   alarm_description = "At least ${var.unhealthy_target_threshold} targets are unhealthy in target group ${each.key}."
@@ -12,7 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_target_alarm" {
 
   dimensions = {
     LoadBalancer = var.load_balancer_id
-    TargetGroup  = each.key
+    TargetGroup  = each.value
   }
 
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation
@@ -25,7 +25,7 @@ resource "aws_cloudwatch_metric_alarm" "unhealthy_target_alarm" {
 }
 
 resource "aws_cloudwatch_metric_alarm" "error_rate_alarm" {
-  for_each = toset(var.target_group_ids)
+  for_each = var.target_group_ids
 
   alarm_name        = "Elevated 5xx for targets in group ${each.key}"
   alarm_description = "Observed more than ${var.error_threshold} 5xx errors for target ${each.key} in window."
@@ -38,7 +38,7 @@ resource "aws_cloudwatch_metric_alarm" "error_rate_alarm" {
 
   dimensions = {
     LoadBalancer = var.load_balancer_id
-    TargetGroup  = each.key
+    TargetGroup  = each.value
   }
 
   # https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/AlarmThatSendsEmail.html#alarm-evaluation

--- a/terraform/modules/alarms/load_balancer/variables.tf
+++ b/terraform/modules/alarms/load_balancer/variables.tf
@@ -4,7 +4,7 @@ variable "load_balancer_id" {
 }
 
 variable "target_group_ids" {
-  type        = list(string)
+  type        = map(any)
   description = "The target groups to monitor."
 }
 

--- a/terraform/modules/ecs_cluster/main.tf
+++ b/terraform/modules/ecs_cluster/main.tf
@@ -49,10 +49,8 @@ resource "aws_ecs_cluster_capacity_providers" "capacity_mapping" {
 
 # Create an autoscaling group for instances providing capacity to the ECS cluster.
 resource "aws_autoscaling_group" "asg" {
-  name                = "ecs-${var.name}"
-  vpc_zone_identifier = var.subnets
-
-  desired_capacity      = var.desired_capacity
+  name                  = "ecs-${var.name}"
+  vpc_zone_identifier   = var.subnets
   max_size              = var.max_capacity
   min_size              = var.min_capacity
   protect_from_scale_in = true
@@ -76,6 +74,7 @@ resource "aws_autoscaling_group" "asg" {
 
   lifecycle {
     ignore_changes = [
+      # ASG capacity is managed by ECS.
       desired_capacity,
     ]
   }

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -20,12 +20,6 @@ variable "instance_type" {
   default     = "t4g.micro"
 }
 
-variable "desired_capacity" {
-  type        = number
-  description = "The desired number of ECS-EC2 instances."
-  default     = 1
-}
-
 variable "min_capacity" {
   type        = number
   description = "The minimum number of ECS-EC2 instances."

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -80,6 +80,32 @@ resource "aws_lb_target_group" "api_target_group" {
   }
 }
 
+resource "aws_lb_listener" "game_listener" {
+  load_balancer_arn = aws_lb.lb.arn
+  port              = var.game_listen_port
+  protocol          = "HTTPS"
+  ssl_policy        = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06"
+  certificate_arn   = var.certificate_arn
+
+  default_action {
+    type             = "forward"
+    target_group_arn = aws_lb_target_group.game_target_group.arn
+  }
+}
+
+resource "aws_lb_target_group" "game_target_group" {
+  name             = "${var.name}-game"
+  vpc_id           = var.vpc_id
+  port             = var.game_service_port
+  protocol         = "HTTP"
+  protocol_version = "HTTP1"
+
+  health_check {
+    path    = "/health"
+    matcher = "200"
+  }
+}
+
 resource "aws_lb_listener" "sp_listener" {
   load_balancer_arn = aws_lb.lb.arn
   port              = var.sp_listen_port

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -2,6 +2,10 @@ output "api_target_group_arn" {
   value = aws_lb_target_group.api_target_group.arn
 }
 
+output "game_target_group_arn" {
+  value = aws_lb_target_group.game_target_group.arn
+}
+
 output "sp_target_group_arn" {
   value = aws_lb_target_group.sp_target_group.arn
 }
@@ -13,6 +17,7 @@ output "load_balancer_id" {
 output "target_group_ids" {
   value = [
     aws_lb_target_group.api_target_group.arn_suffix,
+    aws_lb_target_group.game_target_group.arn_suffix,
     aws_lb_target_group.sp_target_group.arn_suffix,
   ]
 }

--- a/terraform/modules/load_balancer/outputs.tf
+++ b/terraform/modules/load_balancer/outputs.tf
@@ -15,9 +15,9 @@ output "load_balancer_id" {
 }
 
 output "target_group_ids" {
-  value = [
-    aws_lb_target_group.api_target_group.arn_suffix,
-    aws_lb_target_group.game_target_group.arn_suffix,
-    aws_lb_target_group.sp_target_group.arn_suffix,
-  ]
+  value = {
+    api  = aws_lb_target_group.api_target_group.arn_suffix
+    game = aws_lb_target_group.game_target_group.arn_suffix
+    sp   = aws_lb_target_group.sp_target_group.arn_suffix
+  }
 }

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -60,11 +60,11 @@ variable "sp_service_port" {
 }
 
 variable "cdn_domain_name" {
-  type = string
+  type        = string
   description = "The CDN domain name to use for static asset redirects."
 }
 
 variable "cdn_path_prefix" {
-  type = string
+  type        = string
   description = "The CDN path prefix to use for static asset requests, e.g. 'staging/'."
 }

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -35,6 +35,18 @@ variable "api_service_port" {
   default     = 3000
 }
 
+variable "game_listen_port" {
+  type        = number
+  description = "Traffic port for the Game listener."
+  default     = 8000
+}
+
+variable "game_service_port" {
+  type        = number
+  description = "Traffic port for the Game service."
+  default     = 8000
+}
+
 variable "sp_listen_port" {
   type        = number
   description = "Traffic port for the SP listener."

--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -21,7 +21,9 @@ module "ecs_alarms" {
   cluster_name = "duelyst-staging"
   service_names = [
     "duelyst-api-staging",
+    "duelyst-game-staging",
     "duelyst-sp-staging",
+    "duelyst-worker-staging",
   ]
   alarm_actions = [module.email_sns_topic.topic_arn]
 }

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -51,7 +51,7 @@ module "ecs_service_game" {
   ecr_repository    = module.ecr_repository_game.id
   deployed_version  = "1.97.0"
   container_count   = 1
-  service_port      = 8000
+  service_port      = 8001
   alb_target_group  = module.staging_load_balancer.game_target_group_arn
 
   environment_variables = [

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -41,6 +41,30 @@ module "ecs_service_api" {
   ]
 }
 
+module "ecs_service_game" {
+  source            = "../modules/ecs_service"
+  name              = "duelyst-game-staging"
+  cluster           = module.ecs_cluster.id
+  capacity_provider = module.ecs_cluster.capacity_provider
+  task_role         = module.ecs_cluster.task_role
+  ecr_registry      = var.ecr_registry_id
+  ecr_repository    = module.ecr_repository_game.id
+  deployed_version  = "1.97.0"
+  container_count   = 1
+  service_port      = 8000
+  alb_target_group  = module.staging_load_balancer.game_target_group_arn
+
+  environment_variables = [
+    { name = "NODE_ENV", value = "staging" },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
+    { name = "FIREBASE_URL", value = var.firebase_url }
+  ]
+
+  secrets = [
+    { name = "FIREBASE_LEGACY_TOKEN", valueFrom = "/duelyst/staging/firebase/legacy-token" }
+  ]
+}
+
 module "ecs_service_sp" {
   source            = "../modules/ecs_service"
   name              = "duelyst-sp-staging"
@@ -65,6 +89,34 @@ module "ecs_service_sp" {
   ]
 }
 
+module "ecs_service_worker" {
+  source            = "../modules/ecs_service"
+  name              = "duelyst-worker-staging"
+  cluster           = module.ecs_cluster.id
+  capacity_provider = module.ecs_cluster.capacity_provider
+  task_role         = module.ecs_cluster.task_role
+  ecr_registry      = var.ecr_registry_id
+  ecr_repository    = module.ecr_repository_worker.id
+  deployed_version  = "1.97.0"
+  container_count   = 1
+  enable_lb         = false
+  service_port      = 0
+  alb_target_group  = ""
+
+  environment_variables = [
+    { name = "NODE_ENV", value = "staging" },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
+    { name = "FIREBASE_URL", value = var.firebase_url },
+    { name = "FIREBASE_PROJECT_ID", value = var.firebase_project }
+  ]
+
+  secrets = [
+    { name = "FIREBASE_CLIENT_EMAIL", valueFrom = "/duelyst/staging/firebase/client-email" },
+    { name = "FIREBASE_PRIVATE_KEY", valueFrom = "/duelyst/staging/firebase/private-key" },
+    { name = "POSTGRES_CONNECTION", valueFrom = "/duelyst/staging/postgres/connection-string" }
+  ]
+}
+
 module "ecs_service_migrate" {
   source            = "../modules/ecs_service"
   name              = "duelyst-migrate-staging"
@@ -75,14 +127,12 @@ module "ecs_service_migrate" {
   ecr_repository    = module.ecr_repository_migrate.id
   deployed_version  = "1.97.0"
   container_count   = 0 # Change to 1 to apply database migrations.
-  container_cpu     = 1
-  container_mem     = 350 # "1GB" instances are actually 936MB; system uses 158MB.
   enable_lb         = false
   service_port      = 0
   alb_target_group  = ""
 
   environment_variables = [
-    { name = "NODE_ENV", value = "staging" },
+    { name = "NODE_ENV", value = "staging" }
   ]
 
   secrets = [

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -2,8 +2,8 @@ module "ecs_cluster" {
   source             = "../modules/ecs_cluster"
   name               = "duelyst-staging"
   ssh_public_key     = var.ssh_public_key
-  desired_capacity   = 1
-  max_capacity       = 1
+  desired_capacity   = 2 # 4 vCPU for 4 services.
+  max_capacity       = 3 # 2 more vCPU for temporary deployment capacity.
   security_group_ids = [module.internal_security_group.id]
   subnets = [
     module.first_subnet.id,

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -56,6 +56,7 @@ module "ecs_service_game" {
 
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
+    { name = "GAME_PORT", value = 8001 },
     { name = "REDIS_HOST", value = module.redis.instance_dns },
     { name = "FIREBASE_URL", value = var.firebase_url }
   ]

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -2,8 +2,7 @@ module "ecs_cluster" {
   source             = "../modules/ecs_cluster"
   name               = "duelyst-staging"
   ssh_public_key     = var.ssh_public_key
-  desired_capacity   = 2 # 4 vCPU for 4 services.
-  max_capacity       = 3 # 2 more vCPU for temporary deployment capacity.
+  max_capacity       = 3 # 2 instances to cover services; 1 more to temporary deploy capacity.
   security_group_ids = [module.internal_security_group.id]
   subnets = [
     module.first_subnet.id,

--- a/terraform/staging/load_balancers.tf
+++ b/terraform/staging/load_balancers.tf
@@ -12,10 +12,12 @@ module "staging_load_balancer" {
   cdn_domain_name = var.cdn_domain_name
   cdn_path_prefix = "staging/"
 
-  api_listen_port  = 443
-  api_service_port = 3000
-  sp_listen_port   = 8000
-  sp_service_port  = 8000
+  api_listen_port   = 443
+  api_service_port  = 3000
+  game_listen_port  = 8000
+  game_service_port = 8000
+  sp_listen_port    = 8000
+  sp_service_port   = 8000
 }
 
 module "staging_ssl_certificate" {

--- a/terraform/staging/load_balancers.tf
+++ b/terraform/staging/load_balancers.tf
@@ -14,8 +14,8 @@ module "staging_load_balancer" {
 
   api_listen_port   = 443
   api_service_port  = 3000
-  game_listen_port  = 8000
-  game_service_port = 8000
+  game_listen_port  = 8001
+  game_service_port = 8001
   sp_listen_port    = 8000
   sp_service_port   = 8000
 }

--- a/terraform/staging/networking.tf
+++ b/terraform/staging/networking.tf
@@ -54,6 +54,11 @@ module "internal_security_group" {
       port        = 8000
       cidr_blocks = ["10.0.0.0/16"]
     },
+    {
+      description = "Allow TCP/8001 from VPC"
+      port        = 8001
+      cidr_blocks = ["10.0.0.0/16"]
+    },
     #{
     #  description = "Temporary SSH access"
     #  port        = 22


### PR DESCRIPTION
## Summary

This gets the Game and Worker services up and running in staging.

Closes #82.

Build Changes (`docker/`, `gulp/`, `scripts/`, etc.):

- Adds Dockerfiles for Game and Worker

Infrastructure Changes (`terraform/`, etc.):

- Adds ECS services, LB listeners, etc. for Game and Worker

## Testing

I have tested my changes in the following scenarios:

- [x] Building the app with `yarn build` succeeds.
- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a practice game locally.
- [x] I am able to log in and complete a practice game in staging.