### PR TITLE
Polishes some ECS configurations

### DIFF
--- a/terraform/modules/alarms/ecs/main.tf
+++ b/terraform/modules/alarms/ecs/main.tf
@@ -4,7 +4,7 @@ resource "aws_cloudwatch_metric_alarm" "cpu_alarm" {
 
   namespace           = "AWS/ECS"
   metric_name         = "CPUUtilization"
-  statistic           = "Maximum"
+  statistic           = "Average"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = var.cpu_threshold
 
@@ -52,7 +52,7 @@ resource "aws_cloudwatch_metric_alarm" "service_cpu_alarm" {
 
   namespace           = "AWS/ECS"
   metric_name         = "CPUUtilization"
-  statistic           = "Maximum"
+  statistic           = "Average"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   threshold           = var.cpu_threshold
 

--- a/terraform/modules/load_balancer/main.tf
+++ b/terraform/modules/load_balancer/main.tf
@@ -68,11 +68,12 @@ resource "aws_lb_listener_rule" "cdn_redirect" {
 }
 
 resource "aws_lb_target_group" "api_target_group" {
-  name             = "${var.name}-api"
-  vpc_id           = var.vpc_id
-  port             = var.api_service_port
-  protocol         = "HTTP"
-  protocol_version = "HTTP1"
+  name                 = "${var.name}-api"
+  vpc_id               = var.vpc_id
+  port                 = var.api_service_port
+  protocol             = "HTTP"
+  protocol_version     = "HTTP1"
+  deregistration_delay = 120 # Down from 300; matches Spot termination delay.
 
   health_check {
     path    = "/healthcheck"
@@ -94,11 +95,12 @@ resource "aws_lb_listener" "game_listener" {
 }
 
 resource "aws_lb_target_group" "game_target_group" {
-  name             = "${var.name}-game"
-  vpc_id           = var.vpc_id
-  port             = var.game_service_port
-  protocol         = "HTTP"
-  protocol_version = "HTTP1"
+  name                 = "${var.name}-game"
+  vpc_id               = var.vpc_id
+  port                 = var.game_service_port
+  protocol             = "HTTP"
+  protocol_version     = "HTTP1"
+  deregistration_delay = 120 # Down from 300.
 
   health_check {
     path    = "/health"
@@ -120,11 +122,12 @@ resource "aws_lb_listener" "sp_listener" {
 }
 
 resource "aws_lb_target_group" "sp_target_group" {
-  name             = "${var.name}-sp"
-  vpc_id           = var.vpc_id
-  port             = var.sp_service_port
-  protocol         = "HTTP"
-  protocol_version = "HTTP1"
+  name                 = "${var.name}-sp"
+  vpc_id               = var.vpc_id
+  port                 = var.sp_service_port
+  protocol             = "HTTP"
+  protocol_version     = "HTTP1"
+  deregistration_delay = 120 # Down from 300.
 
   health_check {
     path    = "/health"

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -2,7 +2,7 @@ module "ecs_cluster" {
   source             = "../modules/ecs_cluster"
   name               = "duelyst-staging"
   ssh_public_key     = var.ssh_public_key
-  max_capacity       = 3 # 2 instances to cover services; 1 more to temporary deploy capacity.
+  max_capacity       = 2 # Increase by 1 to allow graceful deployments without stopping live containers.
   security_group_ids = [module.internal_security_group.id]
   subnets = [
     module.first_subnet.id,


### PR DESCRIPTION
## Summary

Adds a few polish items for the ECS staging deployment.

Closes #84.

Infrastructure Changes (`terraform/`, etc.):

- Uses the `Average` statistic instead of `Maximum` in ECS CPU utilization alarms, to avoid noisy alarms when CPU has brief spikes in a given 60s period.
- Reduces the ALB Target Group deregistration delay from 300s to 120s. This matches the Spot Instance warning period as well, which should align with #87.
- Reduces the ECS cluster size from 3 to 2 instances to avoid unused capacity. Since we're using `t4g.micro` instances, this reduces EC2 costs from $18.39/mo to $12.26/mo.

## Testing

I have tested my changes in the following scenarios:

- [x] Building the app with `yarn build` succeeds.
- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a practice game locally.
- [x] I am able to log in and complete a practice game in staging.
