### PR TITLE
Builds the app in CI

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -23,6 +23,5 @@ Describe your changes here. Remove any inapplicable sections.
 Have you have tested your changes in the following scenarios?
 Feel free to check off scenarios which don't apply.
 
-- [ ] Building the app with `yarn build` succeeds.
 - [ ] Starting backend services locally with `docker compose up` succeeds.
 - [ ] I am able to log in and complete a game locally.

--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -1,0 +1,53 @@
+name: build_app
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    paths:
+      - app/**
+      - config/**
+      - gulp/**
+      - gulpfile.babel.js
+      - package.json
+      - yarn.lock
+
+jobs:
+  build_app:
+    runs-on: ubuntu-latest
+    steps:
+    - name: check out code
+      uses: actions/checkout@v3
+
+    - name: install system dependencies
+      run: sudo apt-get install -y libpng-dev
+
+    - name: install node.js
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16
+
+    # Caching node_modules saves 50s on builds which don't modify dependencies.
+    # Compared to yarn caching, it saves an additional 27 seconds.
+    - name: cache node_modules
+      uses: actions/cache@v3
+      with:
+        path: /home/runner/work/duelyst/duelyst/node_modules
+        key: node-modules-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          node-modules-
+
+    - name: redirect git ssh to https
+      run: |
+        git config --global url."https://github.com/".insteadOf git@github.com:
+        git config --global url."https://".insteadOf git://
+
+    - name: install node dependencies
+      run: yarn install --dev
+
+    - name: install typescript dependencies
+      run: yarn tsc:chroma-js
+
+    - name: build the app
+      run: yarn build


### PR DESCRIPTION
## Summary

Builds the app in CI. This should make it easier to catch issues with the app build on new PRs.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds a `build_app` Github Actions workflow
- Removes the now-redundant `yarn build` testing step from the PR template

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Building the app with `yarn build` succeeds.
- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
