### PR TITLE
Run staging exclusively on Spot instances

### DIFF
--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -2,8 +2,11 @@ module "ecs_cluster" {
   source             = "../modules/ecs_cluster"
   name               = "duelyst-staging"
   ssh_public_key     = var.ssh_public_key
-  max_capacity       = 1 # Increase by 1 to allow graceful deployments without stopping live containers.
-  max_spot_capacity  = 1
+  # Increase capacity by 1 to allow graceful deployments without stopping live containers.
+  min_capacity       = 0
+  max_capacity       = 0
+  min_spot_capacity  = 2
+  max_spot_capacity  = 2
   security_group_ids = [module.internal_security_group.id]
   subnets = [
     module.first_subnet.id,
@@ -46,7 +49,7 @@ module "ecs_service_game" {
   source            = "../modules/ecs_service"
   name              = "duelyst-game-staging"
   cluster           = module.ecs_cluster.id
-  capacity_provider = module.ecs_cluster.capacity_provider
+  capacity_provider = module.ecs_cluster.spot_capacity_provider
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_game.id
@@ -71,7 +74,7 @@ module "ecs_service_sp" {
   source            = "../modules/ecs_service"
   name              = "duelyst-sp-staging"
   cluster           = module.ecs_cluster.id
-  capacity_provider = module.ecs_cluster.capacity_provider
+  capacity_provider = module.ecs_cluster.spot_capacity_provider
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_sp.id


### PR DESCRIPTION
## Summary

Since Spot instances are working so well for API and Staging, and since losing a staging game isn't the biggest deal, let's run all of staging on Spot instances for another 35% cost reduction.

**Infrastructure changes (`terraform/`, etc.):**

- Scales up the Spot capacity provider
- Moves Game and SP to the Spot capacity provider
- Scales down the on-demand capacity provider

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
