### PR TITLE
Gets multiplayer working in staging

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,7 +19,7 @@ Game Server:
 
 - The Game server is a Socket.io WebSocket server which handles multiplayer games.
 - The service enqueues tasks in Redis to be picked up by the workers.
-- The service listens on port 8000 by default.
+- The service listens on port 8001 by default.
 - Code can be found in `server/game.coffee`, and configuration can be found in `config/`.
 
 Single Player (SP) Server:

--- a/app/sdk/networkManager.coffee
+++ b/app/sdk/networkManager.coffee
@@ -98,7 +98,7 @@ class NetworkManager
 				}
 			})
 
-			# When the socket opens, send the token for authetication
+			# When the socket opens, send the token for authentication
 			@socket.on 'connect', (socket) ->
 				# Storage = require 'app/common/storage'
 				# token = Storage.get('token')

--- a/app/sdk/networkManager.coffee
+++ b/app/sdk/networkManager.coffee
@@ -57,19 +57,22 @@ class NetworkManager
 			TelemetryManager.getInstance().setSignal("game","connecting")
 			token = Storage.get('token')
 
-			# determine which server to use
+			# determine which websocket URL to use
 			env = process.env.NODE_ENV || 'development'
 			if env == 'development'
+				# local games use the SP server
 				websocketUrl = "ws://#{window.location.hostname}:8000"
 			else
 				if gameServerAddress?
+					# if a server address was provided, use it
 					websocketUrl = gameServerAddress
 				else
-					# TODO: Use different port numbers for MP/SP games.
 					if gameType == 'single_player'
+						# online single-player games connect to port 8000
 						websocketUrl = "wss://#{window.location.hostname}:8000"
 					else
-						websocketUrl = "wss://#{window.location.hostname}:8000"
+						# online multi-player games connect to port 8001
+						websocketUrl = "wss://#{window.location.hostname}:8001"
 
 			# validate and log websocket URL
 			if !websocketUrl

--- a/config/config.js
+++ b/config/config.js
@@ -26,7 +26,7 @@ const config = convict({
   game_port: {
     doc: 'The game server port to bind.',
     format: 'port',
-    default: 8000,
+    default: 8001,
     env: 'GAME_PORT',
   },
   sp_port: {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -57,7 +57,7 @@ services:
     profiles:
       - donotstart
     ports:
-      - 8000:8000
+      - 8001:8001
     environment:
       REDIS_HOST: redis
       FIREBASE_URL: ${FIREBASE_URL}

--- a/server/api.coffee
+++ b/server/api.coffee
@@ -8,7 +8,7 @@ mkdirp = require 'mkdirp'
 request = require 'request'
 Promise = require 'bluebird'
 Logger = require '../app/common/logger'
-shutdown = require './shutdown'
+shutdownLib = require './shutdown'
 mail = require './mailer'
 Promise.promisifyAll(mail)
 
@@ -109,7 +109,7 @@ setupProduction = () ->
 						Logger.module("SERVER").log "Duelyst '#{env}' started on port #{apiPort}"
 
 process.on 'uncaughtException', (err) ->
-	shutdown.errorShutdown(err)
+	shutdownLib.errorShutdown(err)
 
 if config.isDevelopment()
 	setupDevelopment()

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -15,7 +15,7 @@ moment = require 'moment'
 request = require 'superagent'
 
 # Our modules
-shutdown = require './shutdown'
+shutdownLib = require './shutdown'
 SDK = require '../app/sdk.coffee'
 Logger = require '../app/common/logger.coffee'
 EVENTS = require '../app/common/event_types'
@@ -109,7 +109,7 @@ saveGameCount = (gameCount) ->
 
 # error 'domain' to deal with io.sockets uncaught errors
 d = require('domain').create()
-d.on 'error', shutdown.errorShutdown
+d.on 'error', shutdownLib.errorShutdown
 d.add(io.sockets)
 
 # health ping on socket namespace /health
@@ -1485,7 +1485,7 @@ afterGameOver = (gameId, gameSession, mouseAndUIEvents) ->
 		Logger.module("GAME-OVER").error "[G:#{gameId}]", "ERROR: afterGameOver failed #{error}".red
 
 ### Shutdown Handler ###
-shutdown = () ->
+shutdownHandler = () ->
 	Logger.module("SERVER").log "Shutting down game server."
 	Logger.module("SERVER").log "Active Players: #{playerCount}."
 	Logger.module("SERVER").log "Active Games: #{gameCount}."
@@ -1537,7 +1537,7 @@ shutdown = () ->
 			Logger.module("SERVER").log "Re-assignment failed: #{err.message}. Exiting."
 			process.exit(1)
 
-process.on "SIGTERM", shutdown
-process.on "SIGINT", shutdown
-process.on "SIGHUP", shutdown
-process.on "SIGQUIT", shutdown
+process.on "SIGTERM", shutdownHandler
+process.on "SIGINT", shutdownHandler
+process.on "SIGHUP", shutdownHandler
+process.on "SIGQUIT", shutdownHandler

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -126,7 +126,7 @@ d.run () ->
 		# add the socket to the error domain
 		d.add(socket)
 
-		# Socket is now autheticated, continue to bind other handlers
+		# Socket is now authenticated, continue to bind other handlers
 		Logger.module("IO").debug "DECODED TOKEN ID: #{socket.decoded_token.d.id.blue}"
 
 		savePlayerCount(++playerCount)

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -81,8 +81,9 @@ io.use(
 	)
 )
 module.exports = io
-server.listen config.get('game_port'), () ->
-	Logger.module("GAME SERVER").log "GAME Server <b>#{os.hostname()}</b> started."
+port = config.get('game_port')
+server.listen port, () ->
+	Logger.module("GAME SERVER").log "Game server started on port #{port}"
 
 # redis
 {Redis, Jobs, GameManager} = require './redis/'

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -1486,7 +1486,7 @@ afterGameOver = (gameId, gameSession, mouseAndUIEvents) ->
 
 ### Shutdown Handler ###
 shutdownHandler = () ->
-	Logger.module("SERVER").log "Shutting down game server."
+	Logger.module("SERVER").log "Received shutdown signal; shutting down game server."
 	Logger.module("SERVER").log "Active Players: #{playerCount}."
 	Logger.module("SERVER").log "Active Games: #{gameCount}."
 

--- a/server/game.coffee
+++ b/server/game.coffee
@@ -128,7 +128,7 @@ d.run () ->
 		d.add(socket)
 
 		# Socket is now authenticated, continue to bind other handlers
-		Logger.module("IO").debug "DECODED TOKEN ID: #{socket.decoded_token.d.id.blue}"
+		Logger.module("IO").debug "DECODED TOKEN ID: #{socket.decodedToken.d.id.blue}"
 
 		savePlayerCount(++playerCount)
 
@@ -184,8 +184,8 @@ onGamePlayerJoin = (requestData) ->
 		return
 
 	# if someone is trying to join a game they don't belong to as a player they are not authenticated as
-	if @.decoded_token.d.id != playerId
-		Logger.module("IO").error "[G:#{gameId}]", "join_game -> REFUSING JOIN: A player #{@.decoded_token.d.id.blue} is attempting to join a game as #{playerId.blue}".red
+	if @.decodedToken.d.id != playerId
+		Logger.module("IO").error "[G:#{gameId}]", "join_game -> REFUSING JOIN: A player #{@.decodedToken.d.id.blue} is attempting to join a game as #{playerId.blue}".red
 		@emit "join_game_response",
 			error:"Your player id does not match the one you requested to join a game with. Are you sure you're joining the right game?"
 		return
@@ -352,8 +352,8 @@ onGameSpectatorJoin = (requestData) ->
 		return
 
 	# if someone is trying to join a game they don't belong to as a player they are not authenticated as
-	if @.decoded_token.d.id != spectatorId
-		Logger.module("IO").error "[G:#{gameId}]", "spectate_game -> REFUSING JOIN: A player #{@.decoded_token.d.id.blue} is attempting to join a game as #{playerId.blue}".red
+	if @.decodedToken.d.id != spectatorId
+		Logger.module("IO").error "[G:#{gameId}]", "spectate_game -> REFUSING JOIN: A player #{@.decodedToken.d.id.blue} is attempting to join a game as #{playerId.blue}".red
 		@emit "spectate_game_response",
 			error:"Your login ID does not match the one you requested to spectate the game with."
 		return

--- a/server/routes/api.coffee
+++ b/server/routes/api.coffee
@@ -18,7 +18,7 @@ validators = require '../validators'
 
 router = express.Router()
 
-## Require authetication for all /api routes
+## Require authentication for all /api routes
 router.use '/api', isSignedIn
 
 # All users

--- a/server/routes/matchmaker.coffee
+++ b/server/routes/matchmaker.coffee
@@ -53,7 +53,7 @@ config = require '../../config/config.js'
 env = config.get('env')
 {version} = require '../../version'
 
-## Require authetication
+## Require authentication
 router.use '/matchmaking', isSignedIn
 
 ###*

--- a/server/routes/utility.coffee
+++ b/server/routes/utility.coffee
@@ -38,7 +38,7 @@ loadClientLogsHandlebarsTemplateAsync = new Promise (resolve,reject) ->
 	.catch (err) ->
 		reject(err)
 
-## Require authetication
+## Require authentication
 router.use '/utility', isSignedIn
 
 # Unused handler to facilitate uploading logs to S3.

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -15,7 +15,7 @@ moment = require 'moment'
 request = require 'superagent'
 
 # Our modules
-shutdown = require './shutdown'
+shutdownLib = require './shutdown'
 StarterAI = require './ai/starter_ai'
 SDK = require '../app/sdk.coffee'
 Logger = require '../app/common/logger.coffee'
@@ -1438,7 +1438,7 @@ afterGameOver = (gameId, gameSession, mouseAndUIEvents) ->
 		Logger.module("GAME-OVER").error "[G:#{gameId}]", "ERROR: afterGameOver failed #{error}".red
 
 ### Shutdown Handler ###
-shutdown = () ->
+shutdownHandler = () ->
 	Logger.module("SERVER").log "Shutting down game server."
 	Logger.module("SERVER").log "Active Players: #{playerCount}."
 	Logger.module("SERVER").log "Active Games: #{gameCount}."
@@ -1490,10 +1490,10 @@ shutdown = () ->
 			Logger.module("SERVER").log "Re-assignment failed: #{err.message}. Exiting."
 			process.exit(1)
 
-process.on "SIGTERM", shutdown
-process.on "SIGINT", shutdown
-process.on "SIGHUP", shutdown
-process.on "SIGQUIT", shutdown
+process.on "SIGTERM", shutdownHandler
+process.on "SIGINT", shutdownHandler
+process.on "SIGHUP", shutdownHandler
+process.on "SIGQUIT", shutdownHandler
 
 # region AI
 

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -82,8 +82,9 @@ io.use(
 	)
 )
 module.exports = io
-server.listen config.get('sp_port'), () ->
-	Logger.module("AI SERVER").log "AI Server <b>#{os.hostname()}</b> started."
+port = config.get('sp_port')
+server.listen port, () ->
+	Logger.module("AI SERVER").log "SP server started on port #{port}"
 
 # redis
 {Redis, Jobs, GameManager} = require './redis/'

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -119,7 +119,7 @@ healthPing = io
 
 io.sockets.on "connection", (socket) ->
 	# Socket is now authenticated, continue to bind other handlers
-	# Logger.module("IO").log "DECODED TOKEN ID: #{socket.decoded_token.d.id.blue}"
+	Logger.module("IO").log "DECODED TOKEN ID: #{socket.decodedToken.d.id.blue}"
 	Logger.module("IO").log "TOKEN ID: #{socket.id.blue}"
 
 	savePlayerCount(++playerCount)
@@ -176,11 +176,11 @@ onGamePlayerJoin = (requestData) ->
 		return
 
 	# if someone is trying to join a game they don't belong to as a player they are not authenticated as
-	# if @.decoded_token.d.id != playerId
-	# 	Logger.module("IO").log "[G:#{gameId}]", "join_game -> REFUSING JOIN: A player #{@.decoded_token.d.id.blue} is attempting to join a game as #{playerId.blue}".red
-	# 	@emit "join_game_response",
-	# 		error:"Your player id does not match the one you requested to join a game with. Are you sure you're joining the right game?"
-	# 	return
+	if @.decodedToken.d.id != playerId
+		Logger.module("IO").log "[G:#{gameId}]", "join_game -> REFUSING JOIN: A player #{@.decodedToken.d.id.blue} is attempting to join a game as #{playerId.blue}".red
+		@emit "join_game_response",
+			error:"Your player id does not match the one you requested to join a game with. Are you sure you're joining the right game?"
+		return
 
 	# if a client is already in another game, leave it
 	playerLeaveGameIfNeeded(this)
@@ -347,11 +347,11 @@ onGameSpectatorJoin = (requestData) ->
 		return
 
 	# if someone is trying to join a game they don't belong to as a player they are not authenticated as
-	# if @.decoded_token.d.id != spectatorId
-	# 	Logger.module("IO").log "[G:#{gameId}]", "spectate_game -> REFUSING JOIN: A player #{@.decoded_token.d.id.blue} is attempting to join a game as #{playerId.blue}".red
-	# 	@emit "spectate_game_response",
-	# 		error:"Your login ID does not match the one you requested to spectate the game with."
-	# 	return
+	if @.decodedToken.d.id != spectatorId
+		Logger.module("IO").log "[G:#{gameId}]", "spectate_game -> REFUSING JOIN: A player #{@.decodedToken.d.id.blue} is attempting to join a game as #{playerId.blue}".red
+		@emit "spectate_game_response",
+			error:"Your login ID does not match the one you requested to spectate the game with."
+		return
 
 	Logger.module("IO").log "[G:#{gameId}]", "spectate_game -> spectator:#{spectatorId} is joining game:#{gameId}".cyan
 

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -1439,7 +1439,7 @@ afterGameOver = (gameId, gameSession, mouseAndUIEvents) ->
 
 ### Shutdown Handler ###
 shutdownHandler = () ->
-	Logger.module("SERVER").log "Shutting down game server."
+	Logger.module("SERVER").log "Received shutdown signal; shutting down SP server."
 	Logger.module("SERVER").log "Active Players: #{playerCount}."
 	Logger.module("SERVER").log "Active Games: #{gameCount}."
 

--- a/server/single_player.coffee
+++ b/server/single_player.coffee
@@ -117,7 +117,7 @@ healthPing = io
 			socket.emit 'pong'
 
 io.sockets.on "connection", (socket) ->
-	# Socket is now autheticated, continue to bind other handlers
+	# Socket is now authenticated, continue to bind other handlers
 	# Logger.module("IO").log "DECODED TOKEN ID: #{socket.decoded_token.d.id.blue}"
 	Logger.module("IO").log "TOKEN ID: #{socket.id.blue}"
 

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -28,19 +28,25 @@ resource "aws_ecs_service" "service" {
 }
 
 resource "aws_ecs_task_definition" "task_def" {
-  family             = var.name
-  execution_role_arn = var.task_role
+  family                   = var.name
+  execution_role_arn       = var.task_role
+  requires_compatibilities = []
+  tags                     = {}
 
   container_definitions = jsonencode([
     {
-      name   = var.name
-      image  = "public.ecr.aws/${var.ecr_registry}/${var.ecr_repository}:${var.deployed_version}"
-      cpu    = var.container_cpu
-      memory = var.container_mem
+      name        = var.name
+      image       = "public.ecr.aws/${var.ecr_registry}/${var.ecr_repository}:${var.deployed_version}"
+      essential   = true
+      cpu         = var.container_cpu
+      memory      = var.container_mem
+      mountPoints = []
+      volumesFrom = []
       portMappings = var.enable_lb ? [
         {
           containerPort = var.service_port
           hostPort      = var.service_port
+          protocol      = "tcp"
         }
       ] : []
       logConfiguration = {

--- a/terraform/modules/load_balancer/variables.tf
+++ b/terraform/modules/load_balancer/variables.tf
@@ -38,13 +38,13 @@ variable "api_service_port" {
 variable "game_listen_port" {
   type        = number
   description = "Traffic port for the Game listener."
-  default     = 8000
+  default     = 8001
 }
 
 variable "game_service_port" {
   type        = number
   description = "Traffic port for the Game service."
-  default     = 8000
+  default     = 8001
 }
 
 variable "sp_listen_port" {

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -53,7 +53,7 @@ module "ecs_service_game" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_game.id
-  deployed_version  = "1.97.1"
+  deployed_version  = "1.97.1-socketfix"
   container_count   = 1
   service_port      = 8001
   alb_target_group  = module.staging_load_balancer.game_target_group_arn

--- a/terraform/staging/networking.tf
+++ b/terraform/staging/networking.tf
@@ -87,6 +87,11 @@ module "load_balancer_security_group" {
       description = "Allows TCP/8000 from 0.0.0.0/0"
       port        = 8000
       cidr_blocks = ["0.0.0.0/0"]
+    },
+    {
+      description = "Allows TCP/8001 from 0.0.0.0/0"
+      port        = 8001
+      cidr_blocks = ["0.0.0.0/0"]
     }
   ]
 }


### PR DESCRIPTION
## Summary

I just finished playing a multiplayer game between a Windows client and a Mac client.

**App changes (`app/`, etc.):**

- Changes the port for multiplayer games to 8001 in `app/sdk/networkManager.coffee`

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Sets the default port to 8001 for Game
- Fixes an invalid reference to `socket.decoded_token`, from the old `auth0/socketio-jwt` dependency. In our current dependency this is called `socket.decodedToken`: https://github.com/Thream/socketio-jwt/blob/v2.2.1/src/authorize.ts#L12
- Minor cleanup of multiple things named `shutdown`; now named `shutdownLib` and `shutdownHandler`
- Minor cleanup of startup and shutdown logs in Game and SP
- Fixes some typos
- Updates docs

**Infrastructure changes (`terraform/`, etc.):**

- Opens port 8001 on the load balancer

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
