### PR TITLE
Don't send emails to the backend during login or signup

### DIFF
--- a/app/common/session2.coffee
+++ b/app/common/session2.coffee
@@ -169,7 +169,7 @@ class Session extends EventEmitter
 			debug data
 			@justRegistered = true
 			@emit 'registered'
-			return {email: opts.email, username: opts.username, password: opts.password}
+			return {username: opts.username, password: opts.password}
 
 	isUsernameAvailable: (username) ->
 		return Promise.resolve(

--- a/app/common/session2.coffee
+++ b/app/common/session2.coffee
@@ -171,27 +171,6 @@ class Session extends EventEmitter
 			@emit 'registered'
 			return {email: opts.email, username: opts.username, password: opts.password}
 
-	isEmailAvailable: (email) ->
-		return Promise.resolve(
-			fetch "#{@url}/session/email_available",
-				method: 'POST'
-				headers:
-					'Accept': 'application/json'
-					'Content-Type': 'application/json'
-				body: JSON.stringify({email: email})
-		)
-		.then (res) ->
-			# available
-			if res.ok then return true
-			# 401 result suggests email is bad or unavailable
-			if res.status == 401 then return false
-			# all other results suggest server is unavailable or had an error
-			# so assume email is valid and let the server handle it in the later registration request
-			return true
-		.catch (e) ->
-			debug("isEmailAvailable #{e.message}")
-			return true
-
 	isUsernameAvailable: (username) ->
 		return Promise.resolve(
 			fetch "#{@url}/session/username_available",

--- a/app/localization/locales/de/index.json
+++ b/app/localization/locales/de/index.json
@@ -3365,7 +3365,7 @@
     "gift_code_default": "Geschenkcode"
   },
   "login": {
-    "email_input_label": "E-Mail oder Benutzername",
+    "username_input_label": "Benutzername",
     "password_input_label": "Passwort",
     "login_button_label": "Anmelden",
     "forgot_password_button_label": "Passwort vergessen?",

--- a/app/localization/locales/en/login.json
+++ b/app/localization/locales/en/login.json
@@ -1,5 +1,5 @@
 {
-	"email_input_label": "Email or Username",
+	"username_input_label": "Username",
 	"password_input_label": "Password",
 	"login_button_label": "Login",
 	"forgot_password_button_label": "Forgot Password?",

--- a/app/ui/templates/item/login_menu.hbs
+++ b/app/ui/templates/item/login_menu.hbs
@@ -133,7 +133,7 @@
 
 <div class="login-form">
     <div class="form-group">
-      <input type="email" class="form-control login-email" placeholder="{{localize 'login.email_input_label'}}">
+      <input type="text" class="form-control login-username" placeholder="{{localize 'login.username_input_label'}}">
     </div>
     <div class="form-group">
       <div class="input-group">

--- a/app/ui/views/item/login_menu.js
+++ b/app/ui/views/item/login_menu.js
@@ -32,7 +32,7 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 		$registrationBlock: ".registration-block",
 		$registration: ".registration",
 		$forgotPassword: ".forgot-password",
-		$email: ".login-email",
+		$username: ".login-username",
 		$password: ".login-password"
 	},
 
@@ -165,7 +165,7 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 	/* region LOGIN */
 
 	onLogin: function() {
-		var email = this.ui.$email.val();
+		var username = this.ui.$username.val();
 		var password = this.ui.$password.val();
 
 		this.updateValidState();
@@ -176,7 +176,7 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 
 			// lockdown user triggered navigation while we login
 			NavigationManager.getInstance().requestUserTriggeredNavigationLocked(this._userNavLockId);
-			Session.login(email, password)
+			Session.login(username, password)
 			.bind(this)
 			.catch(function (e) {
 				// onError expects a string not an actual error
@@ -192,19 +192,16 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 	},
 
 	updateValidState: function () {
-		var usernameOrEmail = this.ui.$email.val();
+		var username = this.ui.$username.val();
 		var password = this.ui.$password.val();
 		this.isValid = true;
 
-		// check email
-		if (usernameOrEmail.indexOf('@') > 0 && !validator.isEmail(usernameOrEmail)) {
-			this.showInvalidFormControlWithTooltip(this.ui.$email, i18next.t("login.invalid_email_message"));
-			this.isValid = false;
-		} else if (usernameOrEmail.indexOf('@') < 0 && (!validator.isLength(usernameOrEmail,3, 18) || !validator.isAlphanumeric(usernameOrEmail))) {
-			this.showInvalidFormControlWithTooltip(this.ui.$email, i18next.t("login.invalid_username_message"));
+		// check username
+		if ((!validator.isLength(username, 3, 18) || !validator.isAlphanumeric(username))) {
+			this.showInvalidFormControlWithTooltip(this.ui.$username, i18next.t("login.invalid_username_message"));
 			this.isValid = false;
 		} else {
-			this.showValidFormControl(this.ui.$email);
+			this.showValidFormControl(this.ui.$username);
 		}
 
 		// check password
@@ -217,7 +214,7 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 	},
 
 	resetInvalidState: function () {
-		this.showValidFormControl(this.ui.$email);
+		this.showValidFormControl(this.ui.$username);
 		this.showValidFormControl(this.ui.$password);
 	},
 
@@ -267,7 +264,7 @@ var LoginMenuItemView = Backbone.Marionette.ItemView.extend({
 		if (errorMessage.indexOf("suspended") > 0) {
 			NavigationManager.getInstance().showDialogViewByClass(ErrorDialogItemView,{title:i18next.t("login.account_suspended_message"),message:errorMessage});
 		} else {
-			this.showInvalidFormControlWithTooltip(this.ui.$email, errorMessage || i18next.t("login.invalid_username_or_password_message"));
+			this.showInvalidFormControlWithTooltip(this.ui.$username, errorMessage || i18next.t("login.invalid_username_or_password_message"));
 			this.showInvalidFormControl(this.ui.$password);
 		}
 	},

--- a/app/ui/views/item/registration.js
+++ b/app/ui/views/item/registration.js
@@ -193,7 +193,7 @@ var RegistrationItemView = FormPromptModalItemView.extend({
 		NavigationManager.getInstance().requestUserTriggeredNavigationLocked(this._userNavLockId);
 
 		// log user in
-		Session.login(registration.email, registration.password)
+		Session.login(registration.username, registration.password)
 		.finally(function () {
 			// unlock user triggered navigation
 			NavigationManager.getInstance().requestUserTriggeredNavigationUnlocked(this._userNavLockId);

--- a/app/ui/views/item/registration.js
+++ b/app/ui/views/item/registration.js
@@ -106,25 +106,6 @@ var RegistrationItemView = FormPromptModalItemView.extend({
 		var inviteCode = this.ui.$inviteCode.val();
 		var isValid = true;
 
-		// check email
-		if (this._hasModifiedEmail && !this._emailUnavailable) {
-			if (!validator.isEmail(email)) {
-				this.showInvalidFormControl(this.ui.$email, i18next.t("registration.registration_validation_invalid_email"));
-				isValid = false;
-			} else {
-				this.showValidFormControl(this.ui.$email);
-
-				// attempt to check whether email is available, but don't block registration for it
-				Session.isEmailAvailable(email)
-				.then(function (available) {
-					if (!available) {
-						this._emailUnavailable = true;
-						this.showInvalidFormControl(this.ui.$email, i18next.t("registration.registration_validation_email_exists"));
-					}
-				}.bind(this));
-			}
-		}
-
 		// check username
 		if (isValid && this._hasModifiedUsername && !this._usernameUnavailable) {
 			if (!validator.isLength(username,3, 18) || !validator.isAlphanumeric(username)) {

--- a/app/ui/views/item/registration.js
+++ b/app/ui/views/item/registration.js
@@ -169,7 +169,6 @@ var RegistrationItemView = FormPromptModalItemView.extend({
 		var captcha = $("#g-recaptcha-response").val()
 
 		Session.register({
-			email: email,
 			username: username,
 			password: password,
 			keycode: inviteCode.length > 0 ? inviteCode : undefined ,

--- a/server/routes/session.coffee
+++ b/server/routes/session.coffee
@@ -202,7 +202,6 @@ router.post "/session/register", (req, res, next) ->
 		return res.status(400).json(result.errors)
 
 	password = result.value.password
-	email = result.value.email.toLowerCase()
 	username = result.value.username.toLowerCase()
 	inviteCode = result.value.keycode?.trim()
 	referralCode = result.value.referral_code?.trim()
@@ -242,6 +241,7 @@ router.post "/session/register", (req, res, next) ->
 	.then (isCaptchaVerified) ->
 		if not isCaptchaVerified
 			throw new Errors.UnverifiedCaptchaError("We could not verify the captcha (bot detection).")
+		email = null
 		return UsersModule.createNewUser(email,username,password,inviteCode,referralCode,campaignData,registrationSource)
 	.then (userId) ->
 		# if we have a friend referral code just fire off async the job to link these two together
@@ -272,8 +272,8 @@ router.post "/session/register", (req, res, next) ->
 	.catch Errors.InvalidReferralCodeError, (e) ->	# Specific error if the invite code is invalid
 		Logger.module("Session").error "can not register because referral code #{referralCode?.yellow} is invalid".red
 		return res.status(400).json(e)
-	.catch Errors.AlreadyExistsError, (e) ->	# Specific error if the email/user already exists
-		Logger.module("Session").error "can not register because username #{username?.blue} or email already exists".red
+	.catch Errors.AlreadyExistsError, (e) ->	# Specific error if the user already exists
+		Logger.module("Session").error "can not register because username #{username?.blue} already exists".red
 		return res.status(401).json(e)
 	.catch Errors.UnverifiedCaptchaError, (e) ->	# Specific error if the captcha fails
 		Logger.module("Session").error "can not register because captcha #{captcha} input is invalid".red

--- a/server/validators/index.js
+++ b/server/validators/index.js
@@ -9,7 +9,6 @@ const token = t.struct({
 
 const loginInput = t.struct({
   password: types.Password,
-  email: t.maybe(types.Email),
   username: t.maybe(types.Username),
 });
 
@@ -36,7 +35,6 @@ const discourseSsoInput = t.struct({
 
 const signupInput = t.struct({
   password: types.NewPassword,
-  email: types.Email,
   username: types.Username,
   keycode: t.maybe(t.Str),
   referral_code: t.maybe(types.ReferralCode),


### PR DESCRIPTION
## Summary

Partial progress on #115. Prevents email information from reaching the backend servers.

**App changes (`app/`, etc.):**

- Disables `isAvailableEmail` checks
- Requires username (not username or email) in login flows
- Removes email from registration requests

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Prevents HTTP/400 on login/signup requests without email addresses
- Forces email to `null` in user creation to prevent email from being stored

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
