### PR TITLE
Resolves max listener warning in worker

### DIFF
--- a/worker/worker.coffee
+++ b/worker/worker.coffee
@@ -9,6 +9,12 @@ if config.isDevelopment()
 	process.env.BLUEBIRD_DEBUG = 1
 	Promise.longStackTraces()
 
+# Increase the number of event listeners in Node.js.
+# The default is 10, but we listen to 14 events in the worker process.
+# Setting this to 15 suppresses benign warnings without losing leak detection.
+events = require 'events'
+events.EventEmitter.defaultMaxListeners = 15
+
 ###
 Job Queue Consumer // aka Worker
 ###


### PR DESCRIPTION
## Summary

Warning:
```
duelyst-worker-1  | (node:72) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 job ttl exceeded listeners added to [Queue]. Use emitter.setMaxListeners() t
o increase limit
duelyst-worker-1  |   at _addListener (node:events:587:17)
duelyst-worker-1  |   at Queue.addListener (node:events:605:10)
duelyst-worker-1  |   at Queue.on (/app/node_modules/kue/lib/kue.js:131:13)
duelyst-worker-1  |   at Worker.start (/app/node_modules/kue/lib/queue/worker.js:82:14)
duelyst-worker-1  |   at Queue.process (/app/node_modules/kue/lib/kue.js:339:41)
duelyst-worker-1  |   at Object.<anonymous> (/app/worker/worker.coffee:73:8)
duelyst-worker-1  |   at Object.<anonymous> (/app/worker/worker.coffee:1:1)
```

Raising the listener count resolves this while still preserving leak detection.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Raises the default max listener count from 10 to 15

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
