### PR TITLE
Improves Cloudflare->S3 CDN cache policies

### DIFF
--- a/terraform/modules/assets_bucket/main.tf
+++ b/terraform/modules/assets_bucket/main.tf
@@ -9,7 +9,7 @@ resource "aws_s3_bucket_cors_configuration" "cors_config" {
     allowed_headers = ["*"]
     allowed_methods = ["GET", "HEAD"]
     allowed_origins = [var.api_origin, var.cdn_origin]
-    expose_headers  = [
+    expose_headers = [
       "Access-Control-Allow-Methods",
       "Access-Control-Allow-Origin",
       "Access-Control-Max-Age",

--- a/terraform/modules/assets_bucket/main.tf
+++ b/terraform/modules/assets_bucket/main.tf
@@ -12,8 +12,9 @@ resource "aws_s3_bucket_cors_configuration" "cors_config" {
     expose_headers  = [
       "Access-Control-Allow-Methods",
       "Access-Control-Allow-Origin",
+      "Access-Control-Max-Age",
       "ETag",
     ]
-    max_age_seconds = 3600
+    max_age_seconds = 86400
   }
 }

--- a/terraform/modules/cloudfront_cdn/distribution.tf
+++ b/terraform/modules/cloudfront_cdn/distribution.tf
@@ -14,27 +14,17 @@ resource "aws_cloudfront_distribution" "distribution" {
 
   # Cache static assets for 10 minutes by default.
   default_cache_behavior {
-    target_origin_id       = var.bucket_origin_id
-    allowed_methods        = ["GET", "HEAD", "OPTIONS"]
-    cached_methods         = ["GET", "HEAD"]
-    viewer_protocol_policy = "https-only"
-    compress               = false
-    #cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
-    #origin_request_policy_id   = aws_cloudfront_origin_request_policy.origin_policy.id
+    target_origin_id           = var.bucket_origin_id
+    allowed_methods            = ["GET", "HEAD", "OPTIONS"]
+    cached_methods             = ["GET", "HEAD"]
+    viewer_protocol_policy     = "https-only"
+    compress                   = false
+    cache_policy_id            = aws_cloudfront_cache_policy.cache_policy.id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
-
-    # Temp revert of above policy usage:
-    min_ttl     = 0
-    default_ttl = 3600
-    max_ttl     = 86400
-    forwarded_values {
-      query_string = false
-      cookies { forward = "none" }
-    }
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.origin_policy.id
   }
 
   # Cache rarely-changed resource assets for 1 day by default.
-  /*
   ordered_cache_behavior {
     path_pattern               = "/${var.cdn_path_prefix}resources/*"
     target_origin_id           = var.bucket_origin_id
@@ -43,10 +33,9 @@ resource "aws_cloudfront_distribution" "distribution" {
     viewer_protocol_policy     = "https-only"
     compress                   = true
     cache_policy_id            = aws_cloudfront_cache_policy.cache_policy_resources.id
-    origin_request_policy_id   = aws_cloudfront_origin_request_policy.origin_policy.id
     response_headers_policy_id = aws_cloudfront_response_headers_policy.response_headers_policy.id
+    origin_request_policy_id   = aws_cloudfront_origin_request_policy.origin_policy.id
   }
-  */
 
   restrictions {
     geo_restriction {

--- a/terraform/modules/cloudfront_cdn/policies.tf
+++ b/terraform/modules/cloudfront_cdn/policies.tf
@@ -1,8 +1,13 @@
+locals {
+  code_ttl     = 3600  # 1 hour.
+  resource_ttl = 86400 # 1 day.
+}
+
 resource "aws_cloudfront_cache_policy" "cache_policy" {
   name        = "cache-policy"
-  min_ttl     = 60    # 1 minute.
-  default_ttl = 600   # 10 minutes.
-  max_ttl     = 86400 # 1 day.
+  min_ttl     = local.code_ttl
+  default_ttl = local.code_ttl
+  max_ttl     = local.code_ttl
 
   parameters_in_cache_key_and_forwarded_to_origin {
     enable_accept_encoding_brotli = false
@@ -25,9 +30,9 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
 
 resource "aws_cloudfront_cache_policy" "cache_policy_resources" {
   name        = "cache-policy-resources"
-  min_ttl     = 600   # 10 minutes.
-  default_ttl = 86400 # 1 day.
-  max_ttl     = 86400 # 1 day.
+  min_ttl     = local.resource_ttl
+  default_ttl = local.resource_ttl
+  max_ttl     = local.resource_ttl
 
   parameters_in_cache_key_and_forwarded_to_origin {
     enable_accept_encoding_brotli = true

--- a/terraform/modules/cloudfront_cdn/policies.tf
+++ b/terraform/modules/cloudfront_cdn/policies.tf
@@ -16,13 +16,7 @@ resource "aws_cloudfront_cache_policy" "cache_policy" {
     cookies_config { cookie_behavior = "none" }
     headers_config {
       header_behavior = "whitelist"
-      headers {
-        items = [
-          "Origin",
-          "Access-Control-Request-Method",
-          "Access-Control-Request-Headers",
-        ]
-      }
+      headers { items = ["Origin"] }
     }
     query_strings_config { query_string_behavior = "none" }
   }
@@ -41,20 +35,12 @@ resource "aws_cloudfront_cache_policy" "cache_policy_resources" {
     cookies_config { cookie_behavior = "none" }
     headers_config {
       header_behavior = "whitelist"
-      headers {
-        items = [
-          "Origin",
-          # Don't think we need these to be part of the cache key.
-          #"Access-Control-Request-Method",
-          #"Access-Control-Request-Headers",
-        ]
-      }
+      headers { items = ["Origin"] }
     }
     query_strings_config { query_string_behavior = "none" }
   }
 }
 
-# https://aws.amazon.com/premiumsupport/knowledge-center/no-access-control-allow-origin-error/
 resource "aws_cloudfront_origin_request_policy" "origin_policy" {
   name = "origin-policy"
 

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -1,12 +1,14 @@
 module "ecs_cluster" {
-  source             = "../modules/ecs_cluster"
-  name               = "duelyst-staging"
-  ssh_public_key     = var.ssh_public_key
+  source         = "../modules/ecs_cluster"
+  name           = "duelyst-staging"
+  ssh_public_key = var.ssh_public_key
+
   # Increase capacity by 1 to allow graceful deployments without stopping live containers.
-  min_capacity       = 0
-  max_capacity       = 0
-  min_spot_capacity  = 2
-  max_spot_capacity  = 2
+  min_capacity      = 0
+  max_capacity      = 0
+  min_spot_capacity = 2
+  max_spot_capacity = 2
+
   security_group_ids = [module.internal_security_group.id]
   subnets = [
     module.first_subnet.id,


### PR DESCRIPTION
## Summary

Closes #116.

**Infrastructure changes (`terraform/`, etc.):**

- Increases max age in S3 from 1h to 24h and exposes the max age header
- Standardizes the cache policy for code with 1h TTL
- Enables the separate cache policy for resources with 24h TTL
- Enables origin policies
- Removes non-Origin headers from CF cache keys

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
