### PR TITLE
Fixes desktop builds on Windows

### DIFF
--- a/desktop/gulp/desktop.js
+++ b/desktop/gulp/desktop.js
@@ -59,7 +59,7 @@ export function build(opts, cb) {
     // by default symlinks are removed, we need to preserve for macOS
     derefSymlinks: opts.platform !== 'darwin',
     arch: opts.arch || 'all',
-    electronVersion: '2.0.0', // First version with JS Exponentiation support.
+    electronVersion: '2.0.18', // First version with JS Exponentiation support.
     // electronVersion: '11.5.0', // First version with support for darwin-arm64.
     // electronVersion: '21.0.1', // Latest version.
     asar: false,

--- a/desktop/gulpfile.babel.js
+++ b/desktop/gulpfile.babel.js
@@ -15,7 +15,7 @@ gulp.task('clean:all', () => del(['dist', 'node_modules']));
 // Manually define platforms and architectures for build tasks.
 gulp.task('desktop:build:darwin:x64', (cb) => desktop.build({ platform: 'darwin', arch: 'x64' }, cb));
 gulp.task('desktop:build:darwin:arm64', (cb) => desktop.build({ platform: 'darwin', arch: 'arm64' }, cb));
-gulp.task('desktop:build:win32', (cb) => desktop.build({ platform: 'win32' }, cb));
+gulp.task('desktop:build:win32', (cb) => desktop.build({ platform: 'win32', arch: 'x64' }, cb));
 
 // Automatically define platforms for Steam & packaging tasks.
 ['darwin', 'win32'].forEach((platform) => {
@@ -57,7 +57,7 @@ gulp.task('desktop:build', gulp.series(
   'desktop:copy',
   'desktop:build:darwin:x64',
   // 'desktop:build:darwin:arm64', // Requires Electron v11.
-  // 'desktop:build:win32',
+  'desktop:build:win32',
 ));
 
 /* Steam & packaging tasks temporarily disabled.

--- a/desktop/gulpfile.babel.js
+++ b/desktop/gulpfile.babel.js
@@ -12,18 +12,6 @@ function validateConfigForDesktop(cb) {
 
 gulp.task('clean:all', () => del(['dist', 'node_modules']));
 
-// Manually define platforms and architectures for build tasks.
-gulp.task('desktop:build:darwin:x64', (cb) => desktop.build({ platform: 'darwin', arch: 'x64' }, cb));
-gulp.task('desktop:build:darwin:arm64', (cb) => desktop.build({ platform: 'darwin', arch: 'arm64' }, cb));
-gulp.task('desktop:build:win32', (cb) => desktop.build({ platform: 'win32', arch: 'x64' }, cb));
-
-// Automatically define platforms for Steam & packaging tasks.
-['darwin', 'win32'].forEach((platform) => {
-  // Temporarily disable Steam & packaging steps.
-  // gulp.task(`desktop:build:steam:${platform}`, (cb) => desktop.build({ platform, steam: true }, cb));
-  // gulp.task(`desktop:zip:${platform}`, (cb) => desktop.zip(platform, cb));
-});
-
 gulp.task('desktop:copy', desktop.copy);
 gulp.task('desktop:yarn', desktop.yarn);
 gulp.task('desktop:shasums', desktop.shasums);
@@ -46,19 +34,57 @@ gulp.task('desktop:git', gulp.series(
 ));
 */
 
-gulp.task('desktop:build', gulp.series(
+// Build the Windows desktop client.
+gulp.task('desktop:build:win32:x64', (cb) => desktop.build({ platform: 'win32', arch: 'x64' }, cb));
+gulp.task('desktop:build:windows', gulp.series(
   validateConfigForDesktop,
   'clean:all',
-  // 'source',
-  // 'rsx:codex_urls',
-  // 'rsx:copy',
+  'desktop:setup',
+  'desktop:yarn',
+  'desktop:copy',
+  'desktop:build:win32:x64',
+));
+
+// Build the Mac desktop client.
+gulp.task('desktop:build:darwin:x64', (cb) => desktop.build({ platform: 'darwin', arch: 'x64' }, cb));
+gulp.task('desktop:build:mac', gulp.series(
+  validateConfigForDesktop,
+  'clean:all',
   'desktop:setup',
   'desktop:yarn',
   'desktop:copy',
   'desktop:build:darwin:x64',
-  // 'desktop:build:darwin:arm64', // Requires Electron v11.
-  'desktop:build:win32',
 ));
+
+// Build the Mac M1 desktop client.
+gulp.task('desktop:build:darwin:arm64', (cb) => desktop.build({ platform: 'darwin', arch: 'arm64' }, cb));
+gulp.task('desktop:build:macm1', gulp.series(
+  validateConfigForDesktop,
+  'clean:all',
+  'desktop:setup',
+  'desktop:yarn',
+  'desktop:copy',
+  'desktop:build:darwin:arm64',
+));
+
+// Build all available desktop clients.
+gulp.task('desktop:build', gulp.series(
+  validateConfigForDesktop,
+  'clean:all',
+  'desktop:setup',
+  'desktop:yarn',
+  'desktop:copy',
+  'desktop:build:win32:x64',
+  'desktop:build:darwin:x64',
+  // 'desktop:build:darwin:arm64', // Requires Electron v11.
+));
+
+// Automatically define platforms for Steam & packaging tasks.
+['darwin', 'win32'].forEach((platform) => {
+  // Temporarily disable Steam & packaging steps.
+  // gulp.task(`desktop:build:steam:${platform}`, (cb) => desktop.build({ platform, steam: true }, cb));
+  // gulp.task(`desktop:zip:${platform}`, (cb) => desktop.zip(platform, cb));
+});
 
 /* Steam & packaging tasks temporarily disabled.
 gulp.task('desktop:build:steam', gulp.series(
@@ -87,10 +113,3 @@ gulp.task('desktop:package:steam', gulp.series(
   desktop.steamUpload,
 ));
 */
-
-gulp.task('desktop:build:dev', gulp.series(
-  // 'rsx:packages',
-  // 'source',
-  // 'rsx:copy',
-  'desktop:copy',
-));

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -29,9 +29,9 @@
   "scripts": {
     "build:all": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build",
     "build:all:production": "cross-env NODE_ENV=production node node_modules/gulp/bin/gulp.js desktop:build",
-    "build:windows": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:win32",
-    "build:mac": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:x64",
-    "build:macm1": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:arm64",
+    "build:windows": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:windows",
+    "build:mac": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:mac",
+    "build:macm1": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:macm1",
     "build:steam": "node mode_modules/gulp/bin/gulp.js desktop:build:steam",
     "start:windows": "cross-env ELECTRONC_IS_DEV=1 dist/build/Duelyst-win32-x64/Duelyst.exe",
     "start:mac": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-x64/Duelyst.app",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -33,7 +33,7 @@
     "build:mac": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:x64",
     "build:macm1": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:arm64",
     "build:steam": "node mode_modules/gulp/bin/gulp.js desktop:build:steam",
-    "start:windows": "cross-env ELECTRONC_IS_DEV=1",
+    "start:windows": "cross-env ELECTRONC_IS_DEV=1 dist/build/Duelyst-win32-x64/Duelyst.exe",
     "start:mac": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-x64/Duelyst.app",
     "start:macm1": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-arm64/Duelyst.app"
   }

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -19,6 +19,7 @@
     "babel-core": "^6.26.0",
     "babel-preset-es2015": "^6.24.1",
     "babelify": "^7.3.0",
+    "cross-env": "^7.0.3",
     "devtron": "^1.1.2",
     "electron": "^21.1.1",
     "electron-packager": "^16.0.0",
@@ -26,11 +27,14 @@
     "gulp": "^4.0.2"
   },
   "scripts": {
-    "build": "NODE_ENV=staging node --max_old_space_size=2048 --stack-size=100000 node_modules/gulp/bin/gulp.js desktop:build",
-    "build:mac": "NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin",
-    "build:production": "NODE_ENV=production node --max_old_space_size=2048 --stack-size=100000 node_modules/gulp/bin/gulp.js desktop:build",
-    "build:steam": "node --max_old_space_size=2048 --stack-size=100000 node_modules/gulp/bin/gulp.js desktop:build:steam",
-    "start:mac": "ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-x64/Duelyst.app",
-    "rebuild": "electron-rebuild -v 2.0.0 -f"
+    "build:all": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build",
+    "build:all:production": "cross-env NODE_ENV=production node node_modules/gulp/bin/gulp.js desktop:build",
+    "build:windows": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:win32",
+    "build:mac": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:x64",
+    "build:macm1": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:darwin:arm64",
+    "build:steam": "node mode_modules/gulp/bin/gulp.js desktop:build:steam",
+    "start:windows": "cross-env ELECTRONC_IS_DEV=1",
+    "start:mac": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-x64/Duelyst.app",
+    "start:macm1": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-arm64/Duelyst.app"
   }
 }

--- a/desktop/yarn.lock
+++ b/desktop/yarn.lock
@@ -1362,6 +1362,13 @@ core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn-windows-exe@^1.1.0, cross-spawn-windows-exe@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/cross-spawn-windows-exe/-/cross-spawn-windows-exe-1.2.0.tgz#46253b0f497676e766faf4a7061004618b5ac5ec"

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -1,14 +1,31 @@
 # Building the Desktop Client
 
-Follow these steps to build the desktop client:
+## One-Time Setup
 
-1. Build the app using either the staging or production config. You can use the
-   `scripts/build_staging_app.sh` script for this purpose. This will create all
-   necessary resources in the `dist/src` directory.
-2. From the `desktop` directory, run `yarn install --include=dev`.
-3. Run `yarn build:all`. This will build the staging clients. To build
+Install `cross-env` with `npm install -g cross-env`, which is used to support
+running the steps below on Windows systems in addition to Mac and Linux systems.
+
+## Build the JavaScript Client
+
+The Desktop build will pull in the JavaScript client code, so we'll build that
+first. These commands should be run from the project root directory.
+
+1. Install app dependencies with `yarn install --include=dev`.
+2. Build the app with `cross-env NODE_ENV=staging FIREBASE_URL=FOO API_URL=BAR yarn build`.
+   `FIREBASE_URL` and `API_URL` are HTTPS URLs e.g. `https://staging.duelyst.org`.
+   `FIREBASE_URL` should have a trailing slash, while `API_URL` should not.
+
+Once this is done, the compiled app will be located in `dist/src/`.
+
+## Build the Desktop Client
+
+These commands should be run from the `desktop/` directory, which has its own
+dependencies and scripts.
+
+1. Install desktop dependencies with `yarn install --include=dev`.
+2. Run `yarn build:all`. This will build the staging clients. To build
    production clients, use `yarn build:all:production`.
-4. To run the newly-built app, use `yarn start:windows` or `yarn start:mac`.
+3. To run the newly-built app, use `yarn start:windows` or `yarn start:mac`.
 
 ## Known Issues
 

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -5,16 +5,13 @@ Follow these steps to build the desktop client:
 1. Build the app using either the staging or production config. You can use the
    `scripts/build_staging_app.sh` script for this purpose. This will create all
    necessary resources in the `dist/src` directory.
-2. From the `desktop` directory, run `yarn build`. This will build the staging
-   clients. To build production clients, use `yarn build:production`.
-3. To run the newly-built app, use `yarn start:mac`. Windows support will be
-   added soon.
+2. From the `desktop` directory, run `yarn install --include=dev`.
+3. Run `yarn build:all`. This will build the staging clients. To build
+   production clients, use `yarn build:all:production`.
+4. To run the newly-built app, use `yarn start:windows` or `yarn start:mac`.
 
 ## Known Issues
 
-- The build scripts set environment variables using Linux/Mac format. These
-	will not work on Windows. This will be fixed by creating new Windows-specific
-	build scripts.
-- The Windows client does not build successfully without the `wine` dependency.
+- The Windows client does not build successfully without `wine` on Mac.
 - The packaging of desktop clients into checksummed ZIP files is disabled.
 - The Steam build is not yet working.

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "commander": "2.8.1",
     "concurrent-transform": "^1.0.0",
     "conventional-changelog": "^1.0.1",
+    "cross-env": "^7.0.3",
     "csv-write-stream": "^1.0.0",
     "del": "^2.2.0",
     "envify": "^3.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3541,6 +3541,13 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+cross-env@^7.0.3:
+  version "7.0.3"
+  resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.3.tgz#865264b29677dc015ba8418918965dd232fc54cf"
+  integrity sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+  dependencies:
+    cross-spawn "^7.0.1"
+
 cross-spawn@^5.0.1:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-5.1.0.tgz#e8bd0efee58fcff6f8f94510a0a554bbfa235449"
@@ -3561,7 +3568,7 @@ cross-spawn@^6.0.0:
     shebang-command "^1.2.0"
     which "^1.2.9"
 
-cross-spawn@^7.0.0, cross-spawn@^7.0.2:
+cross-spawn@^7.0.0, cross-spawn@^7.0.1, cross-spawn@^7.0.2:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.3.tgz#f73a85b9d5d41d045551c177e2882d4ac85728a6"
   integrity sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==


### PR DESCRIPTION
## Summary

Closes #136.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds `cross-env` as a dev dependency to the core package and the desktop package
- Cleans up Gulp tasks and enables `win32` builds
- Builds the desktop client with Electron 2.0.18 instead of 2.0.0
- Updates docs

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
