### PR TITLE
Gets replays working

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -98,7 +98,7 @@ const config = convict({
       env: 'S3_ASSETS_BUCKET',
     },
     replaysBucketName: {
-      default: '',
+      default: 'duelyst-games', // Invalid bucket, but makes localdev happy.
       env: 'S3_REPLAYS_BUCKET',
     },
     cdnDomainName: {
@@ -106,7 +106,7 @@ const config = convict({
       env: 'CDN_DOMAIN_NAME',
     },
     region: {
-      default: '',
+      default: 'us-east-1',
       env: 'AWS_REGION',
     },
     accessKey: {

--- a/config/production.json
+++ b/config/production.json
@@ -10,8 +10,7 @@
 			"Bucket": "duelyst-assets"
 		},
 		"accessKeyId": "",
-		"secretAccessKey": "",
-		"region": "us-west-2"
+		"secretAccessKey": ""
 	},
 	"analyticsEnabled": true,
 	"gaId":"",

--- a/server/routes/api/me/games.coffee
+++ b/server/routes/api/me/games.coffee
@@ -39,6 +39,9 @@ Cards = require '../../../../app/sdk/cards/cardsLookupComplete'
 GameSetups = require '../../../ai/decks/game_setups'
 CosmeticsFactory = require '../../../../app/sdk/cosmetics/cosmeticsFactory'
 
+awsRegion = config.get('aws.region')
+awsReplaysBucket = config.get('aws.replaysBucketName')
+
 router = express.Router()
 
 router.get "/", (req, res, next) ->
@@ -179,7 +182,7 @@ router.get "/watchable/:division_name", (req, res, next) ->
             }
 
           return Promise.map @.gamesData, (gameRow)->
-            gameDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/#{gameRow.id}.json"
+            gameDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/#{gameRow.id}.json"
             Logger.module("API").debug "downloading game #{gameRow.id} replay data from #{gameDataUrl}"
             return new Promise((resolve,reject)->
               request.get(gameDataUrl).end (err, res) ->
@@ -248,8 +251,8 @@ router.get "/watchable/:division_name/:game_id/replay_data", (req, res, next) ->
     return knex("games").where('id',game_id).first()
   .then (row) ->
     if row?
-      gameDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/#{game_id}.json"
-      mouseUIDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/ui_events/#{game_id}.json"
+      gameDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/#{game_id}.json"
+      mouseUIDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/ui_events/#{game_id}.json"
       Logger.module("API").debug "starting download of game #{game_id} replay data from #{gameDataUrl}"
       downloadGameSessionDataAsync = new Promise (resolve,reject)->
         request.get(gameDataUrl).end (err, res) ->

--- a/server/routes/api/me/qa.coffee
+++ b/server/routes/api/me/qa.coffee
@@ -1032,7 +1032,7 @@ router.post '/daily_challenge', (req,res,next)->
     bucket = "duelyst-challenges"
 
     filename = env + "/" + challengeDate + ".json"
-    @.url = "https://s3-us-west-2.amazonaws.com/" + bucket + "/" + filename
+    @.url = "https://s3.#{config.get('aws.region').amazonaws.com/" + bucket + "/" + filename
 
     Logger.module("QA").log "Pushing Daily challenge with url #{@.url}"
 

--- a/server/routes/api/replays/replays.coffee
+++ b/server/routes/api/replays/replays.coffee
@@ -12,6 +12,9 @@ Errors = require '../../../lib/custom_errors'
 generatePushId = require '../../../../app/common/generate_push_id'
 _ = require("underscore")
 
+awsRegion = config.get('aws.region')
+awsReplaysBucket = config.get('aws.replaysBucketName')
+
 router = express.Router()
 
 router.get "/:replay_id", (req, res, next) ->
@@ -27,8 +30,8 @@ router.get "/:replay_id", (req, res, next) ->
     @.replayData = replayData
     if replayData?
       game_id = replayData.game_id
-      gameDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/#{game_id}.json"
-      mouseUIDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/ui_events/#{game_id}.json"
+      gameDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/#{game_id}.json"
+      mouseUIDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/ui_events/#{game_id}.json"
       Logger.module("API").debug "starting download of game #{game_id} replay data from #{gameDataUrl}"
 
       downloadGameSessionDataAsync = new Promise (resolve,reject)->

--- a/server/routes/api/users/games.coffee
+++ b/server/routes/api/users/games.coffee
@@ -15,6 +15,9 @@ generatePushId = require '../../../../app/common/generate_push_id'
 Consul = require '../../../lib/consul'
 _ = require("underscore")
 
+awsRegion = config.get('aws.region')
+awsReplaysBucket = config.get('aws.replaysBucketName')
+
 router = express.Router()
 
 router.get "/", (req, res, next) ->
@@ -49,8 +52,7 @@ router.get "/:game_id/replay_data", (req, res, next) ->
   .then (row) ->
     if row?
       downloadGameSessionDataAsync = new Promise (resolve,reject)->
-        # FIXME: Hardcoded S3 URL.
-        gameDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/#{game_id}.json"
+        gameDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/#{game_id}.json"
         Logger.module("API").debug "starting download of game #{game_id} replay data from #{gameDataUrl}"
         request.get(gameDataUrl).end (err, res) ->
           if res? && res.status >= 400
@@ -65,8 +67,7 @@ router.get "/:game_id/replay_data", (req, res, next) ->
             return resolve(res.text)
 
       downloadMouseUIDataAsync = new Promise (resolve,reject)->
-        # FIXME: Hardcoded S3 URL.
-        mouseUIDataUrl = "https://s3-us-west-1.amazonaws.com/duelyst-games/#{config.get('env')}/ui_events/#{game_id}.json"
+        mouseUIDataUrl = "https://s3.#{awsRegion}.amazonaws.com/#{awsReplaysBucket}/#{config.get('env')}/ui_events/#{game_id}.json"
         request.get(mouseUIDataUrl).end (err, res) ->
           if res? && res.status >= 400
             # Network failure, we should probably return a more intuitive error object

--- a/server/routes/utility.coffee
+++ b/server/routes/utility.coffee
@@ -56,7 +56,7 @@ router.post "/utility/client_logs", (req, res, next) ->
   bucket = config.get("s3_client_logs.bucket")
   env = config.get("env")
   filename = env + "/#{user_id}/#{log_id}.html"
-  url = "https://s3-us-west-1.amazonaws.com/" + bucket + "/" + filename
+  url = "https://s3.#{config.get('aws.region')}.amazonaws.com/" + bucket + "/" + filename
 
   loadClientLogsHandlebarsTemplateAsync.then (template) ->
     # render client log as HTML

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -37,7 +37,8 @@ module "ecs_service_api" {
     { name = "FIREBASE_PROJECT_ID", value = var.firebase_project },
     { name = "CDN_DOMAIN_NAME", value = var.cdn_domain_name },
     { name = "ALL_CARDS_AVAILABLE", value = true },
-    { name = "DEFAULT_GAME_SERVER", value = var.staging_domain_name }
+    { name = "DEFAULT_GAME_SERVER", value = var.staging_domain_name },
+    { name = "S3_REPLAYS_BUCKET", value = var.replays_bucket_name }
   ]
 
   secrets = [

--- a/worker/worker.coffee
+++ b/worker/worker.coffee
@@ -52,6 +52,7 @@ process.on "SIGABRT", cleanShutdown
 ###
 Setup Jobs
 ###
+archiveGame = require './jobs/archive-game.coffee'
 updateUserPostGame = require './jobs/update-user-post-game.coffee'
 updateUserAchievements = require './jobs/update-user-achievements.coffee'
 updateUserChargeLog = require './jobs/update-user-charge-log.coffee'
@@ -66,6 +67,7 @@ processUserReferralEvent = require './jobs/process-user-referral-event.coffee'
 updateUsersRatings = require './jobs/update-users-ratings.coffee'
 updateUserSeenOn = require './jobs/update-user-seen-on.coffee'
 
+worker.process('archive-game', 1, archiveGame)
 worker.process('update-user-post-game', 2, updateUserPostGame)
 worker.process('update-user-achievements', 1, updateUserAchievements)
 worker.process('update-user-charge-log', 1, updateUserChargeLog)
@@ -79,8 +81,3 @@ worker.process('data-sync-steam-friends', 1, dataSyncSteamFriends)
 worker.process('process-user-referral-event', 1, processUserReferralEvent)
 worker.process('update-users-ratings', 1, updateUsersRatings )
 worker.process('update-user-seen-on', 1, updateUserSeenOn )
-
-# Don't attempt S3 uploads in local development.
-if config.get('env') != 'development'
-  archiveGame = require './jobs/archive-game.coffee'
-  worker.process('archive-game', 1, archiveGame)


### PR DESCRIPTION
## Summary

Closes #142. Already deployed in staging.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Adds defaults for AWS region (us-east-1) and replays bucket (duelyst-games) in config
- Replaces hardcoded AWS regions and bucket names in API code
- Re-enables the upload worker in development

**Infrastructure changes (`terraform/`, etc.):**

- Adds `S3_REPLAYS_BUCKET` env var to API service

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
