### PR TITLE
Resizes container memory allocations

### DIFF
--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -27,6 +27,7 @@ module "ecs_service_api" {
   ecr_repository    = module.ecr_repository_api.id
   deployed_version  = "1.97.3"
   container_count   = 1
+  container_mem     = 500 # Runs out of memory with 350MB.
   service_port      = 3000
   alb_target_group  = module.staging_load_balancer.api_target_group_arn
 
@@ -59,6 +60,7 @@ module "ecs_service_game" {
   ecr_repository    = module.ecr_repository_game.id
   deployed_version  = "1.97.1-socketfix"
   container_count   = 1
+  container_mem     = 200 # Uses about 125MB.
   service_port      = 8001
   alb_target_group  = module.staging_load_balancer.game_target_group_arn
 
@@ -84,6 +86,7 @@ module "ecs_service_sp" {
   ecr_repository    = module.ecr_repository_sp.id
   deployed_version  = "1.97.1"
   container_count   = 1
+  container_mem     = 200 # Uses about 125MB.
   service_port      = 8000
   alb_target_group  = module.staging_load_balancer.sp_target_group_arn
 
@@ -108,6 +111,7 @@ module "ecs_service_worker" {
   ecr_repository    = module.ecr_repository_worker.id
   deployed_version  = "1.97.3"
   container_count   = 1
+  container_mem     = 500 # Uses about 315MB.
   enable_lb         = false
   service_port      = 0
   alb_target_group  = ""
@@ -139,6 +143,7 @@ module "ecs_service_migrate" {
   ecr_repository    = module.ecr_repository_migrate.id
   deployed_version  = "1.97.1"
   container_count   = 0 # Change to 1 to apply database migrations.
+  container_mem     = 200
   enable_lb         = false
   service_port      = 0
   alb_target_group  = ""


### PR DESCRIPTION
## Summary

The containers have been fairly undersized at 350MB each. This is more than enough for the WebSocket servers, but not enough for the API and Worker. Somehow this didn't start running out of memory until today.

**Infrastructure changes (`terraform/`, etc.):**

- Shifts some memory from WebSocket servers (350 -> 200 MB) to API and Worker (350->500 MB).

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
