### PR TITLE
Enables Linux desktop client builds

### DIFF
--- a/desktop/gulp/desktop.js
+++ b/desktop/gulp/desktop.js
@@ -6,12 +6,12 @@ import rename from 'gulp-rename';
 import jeditor from 'gulp-json-editor';
 import tap from 'gulp-tap';
 import ncp from 'ncp';
-import hasha from 'hasha';
+// import hasha from 'hasha';
 import readPkg from 'read-pkg';
 import packager from 'electron-packager';
 import rebuild from 'electron-rebuild';
 import { exec, execSync } from 'child_process';
-import steamcmd from '@counterplay/steamcmd';
+// import steamcmd from '@counterplay/steamcmd';
 import Promise from 'bluebird';
 import {
   config, version, production, staging,
@@ -124,17 +124,15 @@ export function zip(opts, cb) {
     const dittoCmd = `ditto -c -k --sequesterRsrc --keepParent ${macAppDir} ${zipTarget}`;
     return exec(dittoCmd, cb);
   }
-
-  if (opts.platform === 'win32') {
+  if (opts.platform === 'linux' || opts.platform === 'win32') {
     const dittoCmd = `ditto -c -k --sequesterRsrc ${baseDir} ${zipTarget}`;
     return exec(dittoCmd, cb);
   }
-
   console.log(`Unrecognized platform ${opts.platform}; doing nothing`);
   return cb();
 }
 
-// Build the desktop app for the desired platform
+/*
 // Create new .SHA1SUM file, contains SHA1 hash + '  ' + filename
 // eg: duelyst-staging-v1.0.38-darwin-x64.zip.SHA1SUM contains
 // 10406a22124b4a0a9c32b34e3682ba601c6578ce  duelyst-staging-v1.0.38-darwin-x64.zip
@@ -142,7 +140,7 @@ export function shasums(cb) {
   if (!production && !staging) {
     return cb(new Error('Current NODE_ENV not supported'));
   }
-  return gulp.src('dist/desktop/*.zip')
+  return gulp.src('dist/build/*.zip')
     .pipe(tap((file) => {
       file.contents = Buffer.concat([
         Buffer.from(hasha(file.contents, { encoding: 'hex', algorithm: 'sha1' })),
@@ -155,7 +153,7 @@ export function shasums(cb) {
       p.extname = '.zip.SHA1SUM';
       return p.extname;
     }))
-    .pipe(gulp.dest('dist/desktop'));
+    .pipe(gulp.dest('dist/build'));
 }
 
 // Prep the macOS app for Steam
@@ -178,3 +176,4 @@ export function steamUpload() {
     appVdf: production ? './config/steam/app_291410.vdf' : './config/steam/app_staging_291410.vdf',
   });
 }
+*/

--- a/desktop/gulpfile.babel.js
+++ b/desktop/gulpfile.babel.js
@@ -11,10 +11,9 @@ function validateConfigForDesktop(cb) {
 }
 
 gulp.task('clean:all', () => del(['dist', 'node_modules']));
-
 gulp.task('desktop:copy', desktop.copy);
 gulp.task('desktop:yarn', desktop.yarn);
-gulp.task('desktop:shasums', desktop.shasums);
+// gulp.task('desktop:shasums', desktop.shasums);
 gulp.task('desktop:setup', desktop.setup);
 
 /* Git tasks temporarily disabled.
@@ -33,18 +32,6 @@ gulp.task('desktop:git', gulp.series(
   'desktop:git:diff',
 ));
 */
-
-// Build the Windows desktop client.
-gulp.task('desktop:build:win32:x64', (cb) => desktop.build({ platform: 'win32', arch: 'x64' }, cb));
-gulp.task('desktop:zip:win32:x64', (cb) => desktop.zip({ platform: 'win32', arch: 'x64' }, cb));
-gulp.task('desktop:build:windows', gulp.series(
-  validateConfigForDesktop,
-  'clean:all',
-  'desktop:setup',
-  'desktop:yarn',
-  'desktop:copy',
-  'desktop:build:win32:x64',
-));
 
 // Build the Mac desktop client.
 gulp.task('desktop:build:darwin:x64', (cb) => desktop.build({ platform: 'darwin', arch: 'x64' }, cb));
@@ -70,6 +57,30 @@ gulp.task('desktop:build:macm1', gulp.series(
   'desktop:build:darwin:arm64',
 ));
 
+// Build the Linux desktop client.
+gulp.task('desktop:build:linux:x64', (cb) => desktop.build({ platform: 'linux', arch: 'x64' }, cb));
+gulp.task('desktop:zip:linux:x64', (cb) => desktop.zip({ platform: 'linux', arch: 'x64' }, cb));
+gulp.task('desktop:build:linux', gulp.series(
+  validateConfigForDesktop,
+  'clean:all',
+  'desktop:setup',
+  'desktop:yarn',
+  'desktop:copy',
+  'desktop:build:linux:x64',
+));
+
+// Build the Windows desktop client.
+gulp.task('desktop:build:win32:x64', (cb) => desktop.build({ platform: 'win32', arch: 'x64' }, cb));
+gulp.task('desktop:zip:win32:x64', (cb) => desktop.zip({ platform: 'win32', arch: 'x64' }, cb));
+gulp.task('desktop:build:windows', gulp.series(
+  validateConfigForDesktop,
+  'clean:all',
+  'desktop:setup',
+  'desktop:yarn',
+  'desktop:copy',
+  'desktop:build:win32:x64',
+));
+
 // Build all available desktop clients.
 gulp.task('desktop:build', gulp.series(
   validateConfigForDesktop,
@@ -77,18 +88,27 @@ gulp.task('desktop:build', gulp.series(
   'desktop:setup',
   'desktop:yarn',
   'desktop:copy',
-  'desktop:build:win32:x64',
   'desktop:build:darwin:x64',
   // 'desktop:build:darwin:arm64', // Requires Electron v11.
+  'desktop:build:linux:x64',
+  'desktop:build:win32:x64',
 ));
 
-// Automatically define platforms for Steam tasks.
-['darwin', 'win32'].forEach((platform) => {
-  // Temporarily disable Steam tasks.
-  // gulp.task(`desktop:build:steam:${platform}`, (cb) => desktop.build({ platform, steam: true }, cb));
+gulp.task('desktop:package', gulp.series(
+  'desktop:zip:darwin:x64',
+  // 'desktop:zip:darwin:arm64',
+  'desktop:zip:linux:x64',
+  'desktop:zip:win32:x64',
+  // 'desktop:git',
+  // 'desktop:shasums',
+  // 'desktop:git:publish',
+));
+
+/* Steam tasks temporarily disabled.
+['darwin', 'linux', 'win32'].forEach((platform) => {
+  gulp.task(`desktop:build:steam:${platform}`, (cb) => desktop.build({ platform, steam: true }, cb));
 });
 
-/* Steam & packaging tasks temporarily disabled.
 gulp.task('desktop:build:steam', gulp.series(
   validateConfigForDesktop,
   'clean:all',
@@ -98,16 +118,9 @@ gulp.task('desktop:build:steam', gulp.series(
   'desktop:setup',
   'desktop:yarn',
   'desktop:copy',
-  'desktop:build:steam:darwin',
   'desktop:build:steam:win32',
-));
-
-gulp.task('desktop:package', gulp.series(
-  'desktop:zip:darwin:x64',
-  'desktop:zip:win32:x64',
-  'desktop:git',
-  'desktop:shasums',
-  'desktop:git:publish',
+  'desktop:build:steam:darwin',
+  'desktop:build:steam:linux',
 ));
 
 gulp.task('desktop:package:steam', gulp.series(

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -34,15 +34,19 @@
   "scripts": {
     "build:all": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build",
     "build:all:production": "cross-env NODE_ENV=production node node_modules/gulp/bin/gulp.js desktop:build",
-    "build:windows": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:windows",
     "build:mac": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:mac",
     "build:macm1": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:macm1",
+    "build:linux": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:linux",
+    "build:windows": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:build:windows",
     "build:steam": "node mode_modules/gulp/bin/gulp.js desktop:build:steam",
-    "zip:windows": "node node_modules/gulp/bin/gulp.js desktop:zip:win32:x64",
+    "zip:all": "cross-env NODE_ENV=staging node node_modules/gulp/bin/gulp.js desktop:package",
     "zip:mac": "node node_modules/gulp/bin/gulp.js desktop:zip:darwin:x64",
     "zip:macm1": "node node_modules/gulp/bin/gulp.js desktop:zip:darwin:arm64",
-    "start:windows": "cross-env ELECTRONC_IS_DEV=1 dist/build/Duelyst-win32-x64/Duelyst.exe",
+    "zip:linux": "node node_modules/gulp/bin/gulp.js desktop:zip:linux:x64",
+    "zip:windows": "node node_modules/gulp/bin/gulp.js desktop:zip:win32:x64",
     "start:mac": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-x64/Duelyst.app",
-    "start:macm1": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-arm64/Duelyst.app"
+    "start:macm1": "cross-env ELECTRON_IS_DEV=1 open dist/build/Duelyst-darwin-arm64/Duelyst.app",
+    "start:linux": "cross-env ELECTRON_IS_DEV=1 dist/build/Duelyst-linux-x64/Duelyst",
+    "start:windows": "cross-env ELECTRONC_IS_DEV=1 dist/build/Duelyst-win32-x64/Duelyst.exe"
   }
 }

--- a/docs/DESKTOP.md
+++ b/docs/DESKTOP.md
@@ -5,8 +5,8 @@
 Install `cross-env` with `npm install -g cross-env`, which is used to support
 running the steps below on Windows systems in addition to Mac and Linux systems.
 
-On Mac, install Wine with `brew install --cask wine-stable`. You may need to
-manually allow it in the Security & Privacy settings in System Preferences.
+On Mac or Linux, install Wine to enable building Windows desktop clients. On
+Mac, use `brew install --cask wine-stable`.
 
 ## Build the JavaScript Client
 
@@ -15,7 +15,6 @@ first. These commands should be run from the project root directory.
 
 1. Install app dependencies with `yarn install --include=dev`.
 2. Build the app with `cross-env NODE_ENV=staging FIREBASE_URL=FOO API_URL=BAR yarn build`.
-   `FIREBASE_URL` and `API_URL` are HTTPS URLs e.g. `https://staging.duelyst.org`.
    `FIREBASE_URL` should have a trailing slash, while `API_URL` should not.
 
 Once this is done, the compiled app will be located in `dist/src/`.
@@ -26,10 +25,11 @@ These commands should be run from the `desktop/` directory, which has its own
 dependencies and scripts.
 
 1. Install desktop dependencies with `yarn install --include=dev`.
-2. Run `yarn build:all`. This will build the staging clients. To build
-   production clients, use `yarn build:all:production`.
-3. To run the newly-built app, use `yarn start:windows` or `yarn start:mac`.
-4. To package the app, use `yarn zip:windows` or `yarn zip:mac`.
+2. Run `yarn build:all` to build the staging clients. To build production
+   clients, use `yarn build:all:production`. Clients will be in `dist/build`.
+3. To run the newly-built app, use `yarn start:mac`, `yarn:start:linux`,  or
+   `yarn start:windows`.
+4. Run `yarn zip:all` to compress all available desktop clients.
 
 ## Known Issues
 


### PR DESCRIPTION
## Summary

Closes #148.

Tweaks the desktop Yarn/Gulp tasks and updates docs.

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
