### PR TITLE
Deploy 1.97.4 to staging

### DIFF
--- a/desktop/gulp/desktop.js
+++ b/desktop/gulp/desktop.js
@@ -112,9 +112,16 @@ export function zip(opts, cb) {
     return cb();
   }
 
+  // Use 'friendly' names for platforms.
+  const friendlyNames = {
+    darwin: 'mac',
+    linux: 'linux',
+    win32: 'windows',
+  };
+
   const desktopPkgJson = readPkg.sync('package.json');
   const baseDir = `dist/build/${desktopPkgJson.productName}-${opts.platform}-${opts.arch}`;
-  const zipTarget = `dist/build/${desktopPkgJson.name}-v${desktopPkgJson.version}-${opts.platform}-${opts.arch}.zip`;
+  const zipTarget = `dist/build/${desktopPkgJson.name}-v${desktopPkgJson.version}-${friendlyNames[opts.platform]}-${opts.arch}.zip`;
 
   if (opts.platform === 'darwin') {
     // Add symlink named 'Electron' to actual binary

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -25,7 +25,7 @@ module "ecs_service_api" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_api.id
-  deployed_version  = "1.97.3"
+  deployed_version  = "1.97.4"
   container_count   = 1
   container_mem     = 500 # Runs out of memory with 350MB.
   service_port      = 3000
@@ -58,7 +58,7 @@ module "ecs_service_game" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_game.id
-  deployed_version  = "1.97.1-socketfix"
+  deployed_version  = "1.97.4"
   container_count   = 1
   container_mem     = 200 # Uses about 125MB.
   service_port      = 8001
@@ -84,7 +84,7 @@ module "ecs_service_sp" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_sp.id
-  deployed_version  = "1.97.1"
+  deployed_version  = "1.97.4"
   container_count   = 1
   container_mem     = 200 # Uses about 125MB.
   service_port      = 8000
@@ -109,7 +109,7 @@ module "ecs_service_worker" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_worker.id
-  deployed_version  = "1.97.3"
+  deployed_version  = "1.97.4"
   container_count   = 1
   container_mem     = 500 # Uses about 315MB.
   enable_lb         = false
@@ -141,7 +141,7 @@ module "ecs_service_migrate" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_migrate.id
-  deployed_version  = "1.97.1"
+  deployed_version  = "1.97.4"
   container_count   = 0 # Change to 1 to apply database migrations.
   container_mem     = 200
   enable_lb         = false


### PR DESCRIPTION
## Summary

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Tweaks the ZIP package names for desktop clients

**Infrastructure changes (`terraform/`, etc.):**

- Deploys 1.97.4 containers to all staging services

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
