### PR TITLE
Cleans up docs

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,121 @@
+Creative Commons Legal Code
+
+CC0 1.0 Universal
+
+    CREATIVE COMMONS CORPORATION IS NOT A LAW FIRM AND DOES NOT PROVIDE
+    LEGAL SERVICES. DISTRIBUTION OF THIS DOCUMENT DOES NOT CREATE AN
+    ATTORNEY-CLIENT RELATIONSHIP. CREATIVE COMMONS PROVIDES THIS
+    INFORMATION ON AN "AS-IS" BASIS. CREATIVE COMMONS MAKES NO WARRANTIES
+    REGARDING THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS
+    PROVIDED HEREUNDER, AND DISCLAIMS LIABILITY FOR DAMAGES RESULTING FROM
+    THE USE OF THIS DOCUMENT OR THE INFORMATION OR WORKS PROVIDED
+    HEREUNDER.
+
+Statement of Purpose
+
+The laws of most jurisdictions throughout the world automatically confer
+exclusive Copyright and Related Rights (defined below) upon the creator
+and subsequent owner(s) (each and all, an "owner") of an original work of
+authorship and/or a database (each, a "Work").
+
+Certain owners wish to permanently relinquish those rights to a Work for
+the purpose of contributing to a commons of creative, cultural and
+scientific works ("Commons") that the public can reliably and without fear
+of later claims of infringement build upon, modify, incorporate in other
+works, reuse and redistribute as freely as possible in any form whatsoever
+and for any purposes, including without limitation commercial purposes.
+These owners may contribute to the Commons to promote the ideal of a free
+culture and the further production of creative, cultural and scientific
+works, or to gain reputation or greater distribution for their Work in
+part through the use and efforts of others.
+
+For these and/or other purposes and motivations, and without any
+expectation of additional consideration or compensation, the person
+associating CC0 with a Work (the "Affirmer"), to the extent that he or she
+is an owner of Copyright and Related Rights in the Work, voluntarily
+elects to apply CC0 to the Work and publicly distribute the Work under its
+terms, with knowledge of his or her Copyright and Related Rights in the
+Work and the meaning and intended legal effect of CC0 on those rights.
+
+1. Copyright and Related Rights. A Work made available under CC0 may be
+protected by copyright and related or neighboring rights ("Copyright and
+Related Rights"). Copyright and Related Rights include, but are not
+limited to, the following:
+
+  i. the right to reproduce, adapt, distribute, perform, display,
+     communicate, and translate a Work;
+ ii. moral rights retained by the original author(s) and/or performer(s);
+iii. publicity and privacy rights pertaining to a person's image or
+     likeness depicted in a Work;
+ iv. rights protecting against unfair competition in regards to a Work,
+     subject to the limitations in paragraph 4(a), below;
+  v. rights protecting the extraction, dissemination, use and reuse of data
+     in a Work;
+ vi. database rights (such as those arising under Directive 96/9/EC of the
+     European Parliament and of the Council of 11 March 1996 on the legal
+     protection of databases, and under any national implementation
+     thereof, including any amended or successor version of such
+     directive); and
+vii. other similar, equivalent or corresponding rights throughout the
+     world based on applicable law or treaty, and any national
+     implementations thereof.
+
+2. Waiver. To the greatest extent permitted by, but not in contravention
+of, applicable law, Affirmer hereby overtly, fully, permanently,
+irrevocably and unconditionally waives, abandons, and surrenders all of
+Affirmer's Copyright and Related Rights and associated claims and causes
+of action, whether now known or unknown (including existing as well as
+future claims and causes of action), in the Work (i) in all territories
+worldwide, (ii) for the maximum duration provided by applicable law or
+treaty (including future time extensions), (iii) in any current or future
+medium and for any number of copies, and (iv) for any purpose whatsoever,
+including without limitation commercial, advertising or promotional
+purposes (the "Waiver"). Affirmer makes the Waiver for the benefit of each
+member of the public at large and to the detriment of Affirmer's heirs and
+successors, fully intending that such Waiver shall not be subject to
+revocation, rescission, cancellation, termination, or any other legal or
+equitable action to disrupt the quiet enjoyment of the Work by the public
+as contemplated by Affirmer's express Statement of Purpose.
+
+3. Public License Fallback. Should any part of the Waiver for any reason
+be judged legally invalid or ineffective under applicable law, then the
+Waiver shall be preserved to the maximum extent permitted taking into
+account Affirmer's express Statement of Purpose. In addition, to the
+extent the Waiver is so judged Affirmer hereby grants to each affected
+person a royalty-free, non transferable, non sublicensable, non exclusive,
+irrevocable and unconditional license to exercise Affirmer's Copyright and
+Related Rights in the Work (i) in all territories worldwide, (ii) for the
+maximum duration provided by applicable law or treaty (including future
+time extensions), (iii) in any current or future medium and for any number
+of copies, and (iv) for any purpose whatsoever, including without
+limitation commercial, advertising or promotional purposes (the
+"License"). The License shall be deemed effective as of the date CC0 was
+applied by Affirmer to the Work. Should any part of the License for any
+reason be judged legally invalid or ineffective under applicable law, such
+partial invalidity or ineffectiveness shall not invalidate the remainder
+of the License, and in such case Affirmer hereby affirms that he or she
+will not (i) exercise any of his or her remaining Copyright and Related
+Rights in the Work or (ii) assert any associated claims and causes of
+action with respect to the Work, in either case contrary to Affirmer's
+express Statement of Purpose.
+
+4. Limitations and Disclaimers.
+
+ a. No trademark or patent rights held by Affirmer are waived, abandoned,
+    surrendered, licensed or otherwise affected by this document.
+ b. Affirmer offers the Work as-is and makes no representations or
+    warranties of any kind concerning the Work, express, implied,
+    statutory or otherwise, including without limitation warranties of
+    title, merchantability, fitness for a particular purpose, non
+    infringement, or the absence of latent or other defects, accuracy, or
+    the present or absence of errors, whether or not discoverable, all to
+    the greatest extent permissible under applicable law.
+ c. Affirmer disclaims responsibility for clearing rights of other persons
+    that may apply to the Work or any use thereof, including without
+    limitation any person's Copyright and Related Rights in the Work.
+    Further, Affirmer disclaims responsibility for obtaining any necessary
+    consents, permissions or other rights required for any use of the
+    Work.
+ d. Affirmer understands and acknowledges that Creative Commons is not a
+    party to this document and has no duty or obligation with respect to
+    this CC0 or use of the Work.

--- a/README.md
+++ b/README.md
@@ -2,43 +2,54 @@
 
 ![Duelyst Logo](app/resources/ui/brand_duelyst.png)
 
-This is the source code for Duelyst, a digital collectible card game and turn-based strategy hybrid developed by
-Counterplay Games and released in 2016.
+This is the source code for Duelyst, a digital collectible card game and
+turn-based strategy hybrid developed by Counterplay Games and released in 2016.
+
+## Production Deployment
+
+Work is underway to deploy OpenDuelyst as "Duelyst Classic": a version of the
+game exactly as it was in v1.96.17, before the servers were shut down. This is
+being tracked in [issue #3](https://github.com/open-duelyst/duelyst/issues/3).
+
+## Staging Deployment
+
+The staging deployment is up and running at https://staging.duelyst.org. Both
+single-player and multi-player games are available.
+
+## Downloading the Desktop Clients
+
+Desktop clients for Windows, Mac, and Linux can be downloaded on the
+[Releases](https://github.com/open-duelyst/duelyst/releases) page.
+
+Desktop clients currently use the staging environment. They'll use the
+production environment once it's available.
 
 ## Contributing to OpenDuelyst
 
-If you'd like to contribute to OpenDuelyst, check out our [Documentation](docs/README.md), especially the
-[Roadmap](docs/ROADMAP.md) and [Contributor Guide](docs/CONTRIBUTING.md). Following this guide will also enable you to
-play local single player games while we work on the reference deployment.
+If you'd like to contribute to OpenDuelyst, check out our
+[Documentation](docs/README.md), especially the [Roadmap](docs/ROADMAP.md) and
+[Contributor Guide](docs/CONTRIBUTING.md).
 
-## Reference Deployment
-
-Work is underway to deploy OpenDuelyst as "Duelyst Classic": a version of the game exactly as it was in v1.96.17,
-before the servers were shut down. This is being tracked in [issue #3](https://github.com/open-duelyst/duelyst/issues/3).
-
-## Client/Server Architecture
-
-For client and server architecture documentation, see [ARCHITECTURE.md](docs/ARCHITECTURE.md).
+You can also join the OpenDuelyst developer Discord server
+[here](https://discord.gg/HhUWfZ9cxe). This Discord server is focused on the
+development of OpenDuelyst, and has channels for frontend, backend, and
+infrastructure discussions, but it is open for anyone to join.
 
 ## Filing Issues and Reporting Bugs
 
 If you encounter a bug and would like to report it, first check the
-[Open Issues](https://github.com/open-duelyst/duelyst/issues/) to see if the bug has already been reported. If not,
-feel free to create a new issue with the `bug` label.
+[Open Issues](https://github.com/open-duelyst/duelyst/issues/) to see if the
+bug has already been reported. If not, feel free to create a new issue with the
+`bug` label.
 
-If you would like to request a technical feature or enhancement to the code, you can create a new issue with the
-`enhancement` label.
+If you would like to request a technical feature or enhancement to the code,
+you can create a new issue with the `enhancement` label.
 
-Since OpenDuelyst is currently focused on recreating the game as it last existed in v1.96.17, please avoid creating
-feature requests related to balance changes.
-
-## Discord
-
-You can join the OpenDuelyst Discord server [here](https://discord.gg/HhUWfZ9cxe). This Discord server is focused on
-the development of OpenDuelyst, and has channels for frontend, backend, and infrastructure discussion, but is open
-for anyone to join.
+Since OpenDuelyst is currently focused on recreating the game as it last
+existed in v1.96.17, please avoid creating feature requests related to balance
+changes.
 
 ## License
 
-OpenDuelyst is licensed under the Creative Commons Zero v1.0 Universal license. You can see a copy of the license
-[here](LICENSE).
+OpenDuelyst is licensed under the Creative Commons Zero v1.0 Universal license.
+You can see a copy of the license [here](LICENSE).

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -4,7 +4,9 @@
 
 ## Client Architecture
 
-The game client is a Backbone.js + Marionette application which runs in the browser. Code can be found in `app/`, and configuration can be found in `app/common/config.js`.
+The game client is a Backbone.js + Marionette application which runs in the
+browser. Code can be found in `app/`, and configuration can be found in
+`app/common/config.js`.
 
 ## Server Architecture
 
@@ -14,91 +16,123 @@ API Server:
 
 - The API server is an Express.js app which handles routes for game clients.
 - The service stores user and game data in Postgres and Redis.
-- The service listens on port 3000 by default, and it serves the browser client on the default route.
-- Code can be found in `server/api.coffee`, and configuration can be found in `config/`.
+- The service listens on port 3000 by default, and it serves the browser client
+	on the default route.
+- Code can be found in `server/api.coffee`, and configuration can be found in
+	`config/`.
 
 Game Server:
 
-- The Game server is a Socket.io WebSocket server which handles multiplayer games.
+- The Game server is a Socket.io WebSocket server which handles multiplayer
+	games.
 - The service enqueues tasks in Redis to be picked up by the workers.
 - The service listens on port 8001 by default.
-- Code can be found in `server/game.coffee`, and configuration can be found in `config/`.
+- Code can be found in `server/game.coffee`, and configuration can be found in
+	`config/`.
 
 Single Player (SP) Server:
 
-- The SP server is a Socket.io WebSocket server which handles single-player games.
+- The SP server is a Socket.io WebSocket server which handles single-player
+	games.
 - The service enqueues tasks in Redis to be picked up by the workers.
 - The service listens on port 8000 by default.
-- Code can be found in `server/single_player.coffee`, and configuration can be found in `config/`.
+- Code can be found in `server/single_player.coffee`, and configuration can be
+	found in `config/`.
 
 Worker:
 
-- The worker uses Kue to poll Redis-backed queues for tasks like game creation and matchmaking.
-- Some matchmaking tasks also use Postgres, for server healthchecks and retrieving bot users.
-- Code can be found in `worker/worker.coffee`, and configuration can be found in `config/`.
-- A Kue GUI is available at `http://localhost:4000` via `docker compose up worker-ui`).
+- The worker uses Kue to poll Redis-backed queues for tasks like game creation
+	and matchmaking.
+- Some matchmaking tasks also use Postgres, for server healthchecks and
+	retrieving bot users.
+- Code can be found in `worker/worker.coffee`, and configuration can be found
+	in `config/`.
+- A Kue GUI is available at `http://localhost:4000` via
+	`docker compose up worker-ui`).
 
 ## Other Dependencies
 
 Firebase Realtime Database:
 
-- Provides a way to the game client to access both permanent and transient data, without direct access to Postgres, such as transmitting game steps.
-- Client code can be found in `app` (see `new Firebase()` calls) and `server/lib/duelyst_firebase_module.coffee`, and configuration can be found in `config/`
+- Provides a way to the game client to access both permanent and transient
+	data, without direct access to Postgres, such as transmitting game steps.
+- Client code can be found in `app` (see `new Firebase()` calls) and
+	`server/lib/duelyst_firebase_module.coffee`, and configuration can be found
+	in `config/`
 
 Postgres:
 
-- Stores relational data for users, completed games, database migrations, and more
-- Client code can be found in `server/lib/data_access/knex.coffee` and `server/knexfile.js`, and configuration can be found in `config/`
+- Stores relational data for users, completed games, database migrations, and
+	more
+- Client code can be found in `server/lib/data_access/knex.coffee` and
+	`server/knexfile.js`, and configuration can be found in `config/`
 - Migrations can be run via `docker compose up migrate`
-- An admin UI is available at `http://localhost:8080` via `docker compose up adminer`
+- An admin UI is available at `http://localhost:8080` via
+	`docker compose up adminer`
 
 Redis:
 
-- Used as a backing queue for Kue tasks, as well as for matchmaking, game management, player queues, and more
-- Client code can be found in `server/redis/index.coffee`, and configuration can be found in `config/`
+- Used as a backing queue for Kue tasks, as well as for matchmaking, game
+	management, player queues, and more
+- Client code can be found in `server/redis/index.coffee`, and configuration
+	can be found in `config/`
 
 Consul:
 
-- Not required in single-server deployments, but was historically used for service discovery, matchmaking, and spectating
-- Client code can be found in `server/lib/consul.coffee`, and configuration can be found in `config/`
+- Not required in single-server deployments, but was historically used for
+	service discovery, matchmaking, and spectating
+- Client code can be found in `server/lib/consul.coffee`, and configuration can
+	be found in `config/`
 
 AWS S3:
 
 - Provides binary large object (blob) storage for generic file storage.
-- Not currently used, but code is available to use S3 for CDN, unfinished game archiving, client logging, and database backup features.
+- Not currently used, but code is available to use S3 for CDN, unfinished game
+	archiving, client logging, and database backup features.
 
 ## Resource Utilization <a id="resource-utilization" />
 
-The following resource utilization numbers were measured by Docker locally. The baseline numbers were measured when
-idle, and the peak and per-game numbers were measured when playing a practice game (which performs the same work as the
+The following resource utilization numbers were measured by Docker locally. The
+baseline numbers were measured when idle, and the peak and per-game numbers
+were measured when playing a practice game (which performs the same work as the
 Game WebSocket server, plus computational work for AI decisions).
 
 #### Node.js processes (API, Game, SP, Worker):
 
-- CPU: 0-1% baseline; API spikes to 15-65% on loads; SP spikes to 5% on AI processing.
-  - NOTE: The API spikes during loads are largely due to serving 75MB of static assets from Express instead of CDN.
+- CPU: 0-1% baseline; API spikes to 15-65% on loads; SP spikes to 5% on AI
+	processing.
+  - NOTE: The API spikes during loads are largely due to serving 75MB of static
+		assets from Express instead of CDN.
 - Memory: 300MB baseline. API increases to ~500MB over time.
 - Network: Near-zero baseline.
 	- API sends about 500KB per game.
 	- Game and SP send about 200KB per game.
 	- Worker's baseline is 1-2KB/s (internal, unbilled traffic).
-		- This ongoing traffic is due to Kue polling; see `server/redis/r-jobs.coffee`.
-- Storage: About 5GB (2.0GB for OS baseline, 1.3GB for `app/`, 0.8GB for `node_modules/`, 0.5GB for `dist/`)
+		- This ongoing traffic is due to Kue polling; see
+			`server/redis/r-jobs.coffee`.
+- Storage: About 5GB (2.0GB for OS baseline, 1.3GB for `app/`, 0.8GB for
+	`node_modules/`, 0.5GB for `dist/`)
 
 #### Postgres database:
 
 - CPU: Near-zero baseline. Reaches 7% on user retrieval (login etc.)
-- Memory: 20MB baseline. Increases to 70MB after logging in and playing games (caching)
-- Network: Near-zero baseline. Sends 10-15KB (internal, unbilled traffic) on user operations (fetching users, challenges, cards, etc.)
-- Storage: About 1GB (0.5GB for OS baseline, 0.1GB for `/var/lib/postgresql` with ~5 users, ~20 games)
+- Memory: 20MB baseline. Increases to 70MB after logging in and playing games
+	(caching)
+- Network: Near-zero baseline. Sends 10-15KB (internal, unbilled traffic) on
+	user operations (fetching users, challenges, cards, etc.)
+- Storage: About 1GB (0.5GB for OS baseline, 0.1GB for `/var/lib/postgresql`
+	with ~5 users, ~20 games)
 
 #### Redis cache:
 
 - CPU: 1% baseline. Stays under 2% during games.
-	- Redis 6.x has a second thread for connection handling, but we don't benefit much from this at our small scale.
+	- Redis 6.x has a second thread for connection handling, but we don't benefit
+		much from this at our small scale.
 - Memory: 4MB baseline; under 5MB when playing local single player.
-- Network: 1KB/s baseline. Sends under 1MB per game (internal, unbilled traffic).
-	- This ongoing traffic is due to Kue polling; see `server/redis/r-jobs.coffee`.
+- Network: 1KB/s baseline. Sends under 1MB per game (internal, unbilled
+	traffic).
+	- This ongoing traffic is due to Kue polling; see
+		`server/redis/r-jobs.coffee`.
 - Storage: Under 200MB.
 
 #### Total resources used for 250 concurrent, 10-minute games (125 MP, 125 SP):

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 # Contributing to OpenDuelyst
 
 Thanks for your interest in contributing to OpenDuelyst!
-This document will introduce you to the code and guide you through making a change.
+This document will introduce you to the code and guide you through making a
+change.
 
 ## Table of Contents
 
@@ -33,60 +34,69 @@ This document will introduce you to the code and guide you through making a chan
 
 ## Code Structure <a id="code-structure" />
 
-An in-depth explanation of the code can be found in the Architecture Documentation above.
-It contains some pointers to the specific places in the code used by each service or component.
+An in-depth explanation of the code can be found in the Architecture
+Documentation above. It contains some pointers to the specific places in the
+code used by each service or component.
 
-To help you get acquainted more quickly, here is a list of files and directories commonly used when
-working on the game:
+To help you get acquainted more quickly, here is a list of files and
+directories commonly used when working on the game:
 
 - `app/` contains code for the frontend / game client
 - `config/` contains configuration for backend services
 - `docker-compose.yaml` contains our Docker container configuration
 - `docs` contains documentation, including this guide
-- `gulp/` and `gulpfile.babel.js` contain workflow automation, for tasks like building the code
+- `gulp/` and `gulpfile.babel.js` contain workflow automation, for tasks like
+	building the code
 - `package.json` contains our Node.js dependencies
 - `server` contains code for the HTTP API server and the WebSocket game servers
-- `terraform` contains code for provisioning staging and production environments
+- `terraform` contains code for provisioning staging and production
+	environments
 - `test` contains unit and integration tests
-- `worker` contains code for the worker, which processes asynchronous background jobs
+- `worker` contains code for the worker, which processes asynchronous
+	background jobs
 
 #### Code Style and Linting
 
 For JavaScript code, we use ESLint to enforce code style.
 Its configuration can be found in `.eslintrc.json`.
 You can run the linter with `yarn lint:js`.
-You can automatically format JS code to meet these standards by running `yarn format:js`.
+You can automatically format JS code to meet these standards by running
+`yarn format:js`.
 
 For CoffeeScript code, we use CoffeeLint to enforce code style.
 Its configuration can be found in `coffeelint.json`.
-You can run linters with `yarn lint:coffee`, `yarn lint:coffee:app`, or `yarn lint:coffee:backend`.
+You can run linters with `yarn lint:coffee`, `yarn lint:coffee:app`, or
+`yarn lint:coffee:backend`.
 
 #### Regarding JavaScript, CoffeeScript, and TypeScript
 
-Most of the code is written in CoffeeScript, which compiles into JavaScript. We are considering
-replacing CoffeeScript with JavaScript (see
+Most of the code is written in CoffeeScript, which compiles into JavaScript. We
+are considering replacing CoffeeScript with JavaScript (see
 [Issue #4](https://github.com/open-duelyst/duelyst/issues/4)).
 
 We should also consider moving to TypeScript where possible.
-There is a fairly strict `tsconfig.json` in the repo which has been preconfigured for new code.
-After writing new TypeScript code, you can run `yarn tsc` to build it using this config.
+There is a fairly strict `tsconfig.json` in the repo which has been
+preconfigured for new code. After writing new TypeScript code, you can run
+`yarn tsc` to build it using this config.
 
 ## Setting up a Development Environment <a id="dev-environment" />
 
 #### Installing System Dependencies
 
-Before you get started, you'll need [Docker](https://www.docker.com/products/docker-desktop/) and
-[Node.js + NPM](https://nodejs.org/en/download/). These will enable you to run the code in
-containers, and to interact with the JavaScript build process.
+Before you get started, you'll need [Docker](https://www.docker.com/products/docker-desktop/)
+and [Node.js](https://nodejs.org/en/download/). These will enable you to run
+the code in containers, and to interact with the JavaScript build process.
 
-Once you have `npm`, you can use it to install Yarn (the package manager we use):
+Once you have `npm`, you can use it to install Yarn (the package manager we
+use):
 
 ```bash
 npm install -g yarn@1
 npm install -g cross-env
 ```
 
-Before proceeding, disable the deprecated `git://` protocol for fetching packages:
+Before proceeding, disable the deprecated `git://` protocol for fetching
+packages:
 ```
 git config --global url."https://".insteadOf git://
 ```
@@ -108,31 +118,33 @@ In order to successfully run the game, you will need a
 Fortunately, Google provides a free version of this service called the
 ["Spark Pricing Plan"](https://firebase.google.com/docs/projects/billing/firebase-pricing-plans).
 
-Once you have created a Firebase account and a Realtime Database, take note of your Realtime
-Database's URL, as you'll need it when building the code. You will also want to configure the
-Security Rules for your database. You can copy these from [firebaseRules.json](firebaseRules.json)
-in the repo.
+Once you have created a Firebase account and a Realtime Database, take note of
+your Realtime Database's URL, as you'll need it when building the code. You
+will also want to configure the Security Rules for your database. You can copy
+these from [firebaseRules.json](firebaseRules.json) in the repo.
 
 #### Building the Code
 
-Now that dependencies are installed, you can build the game code and its assets! This step will
-take a few minutes.
+Now that dependencies are installed, you can build the game code and its
+assets. This step will take a few minutes.
 
 ```
 cross-env FIREBASE_URL=<YOUR_FIREBASE_URL> yarn build
 ```
 
-Including the Firebase URL is important, since it enables the game client to communicate with the
-servers.
-After the initial build, you can save time with `yarn build:app` (code only; no assets) or
-`yarn build:web` (frontend HTML/CSS/JS only).
+Including the Firebase URL is important, since it enables the game client to
+communicate with the servers.
+
+After the initial build, you can save time with `yarn build:app` (code only; no
+assets) or `yarn build:web` (frontend HTML/CSS/JS only).
 
 ## Starting the Game Locally <a id="starting-the-game" />
 
 #### Additional Firebase Configuration
 
-Now that you have a development environment set up, there's a bit more Firebase configuration
-needed. From your Firebase project settings page, click the "Service Accounts" tab.
+Now that you have a development environment set up, there's a bit more Firebase
+configuration needed. From your Firebase project settings page, click the
+"Service Accounts" tab.
 
 First, click "Database Secrets" and create a new legacy token.
 Create a `.env` file in the repo root with the following contents:
@@ -142,102 +154,115 @@ FIREBASE_URL=<YOUR_FIREBASE_URL>
 FIREBASE_LEGACY_TOKEN=<YOUR_FIREBASE_LEGACY_TOKEN>
 ```
 
-Next, still on the Firebase "Service Accounts" page, click on the Service Accounts popout to open
-Google Cloud. Create a new service account with the ability to read from and write to Firebase.
-You can achieve this by using the "Firebase Realtime Database Admin" role, but you may want to
-restrict this later.
+Next, still on the Firebase "Service Accounts" page, click on the Service
+Accounts popout to open Google Cloud. Create a new service account with the
+ability to read from and write to Firebase. You can achieve this by using the
+"Firebase Realtime Database Admin" role, but you may want to restrict this
+later.
 
-On the Google "Service Accounts" page, clicking "Manage Keys" next to the newly-created service
-account will let you create a new JSON key. Do this, and save it as `serviceAccountKey.json` in the
-repo root.
+On the Google "Service Accounts" page, clicking "Manage Keys" next to the
+newly-created service account will let you create a new JSON key. Do this, and
+save it as `serviceAccountKey.json` in the repo root.
 
-Note: Both `.env` and `serviceAccountKey.json` are ignored by Git for this repo, so these secrets
-can't be accidentally committed.
+Note: Both `.env` and `serviceAccountKey.json` are ignored by Git for this repo,
+so these secrets can't be accidentally committed.
 
 #### Starting with Docker
 
-Now that the game has been built and Firebase has been configured, you can start the servers
-locally and play a game. We use [Docker Compose](https://docs.docker.com/compose/) to manage
-containers for the game servers, Redis cache, and Postgres database.
+Now that the game has been built and Firebase has been configured, you can
+start the servers locally and play a game. We use
+[Docker Compose](https://docs.docker.com/compose/) to manage containers for the
+game servers, Redis cache, and Postgres database.
 
-As a final step before starting the game servers, the Postgres database must be initialized.
-To do this, run `docker compose up migrate`.
+As a final step before starting the game servers, the Postgres database must be
+initialized. To do this, run `docker compose up migrate`.
 
-Now you can run `docker compose up` to start the game servers and their dependencies.
+Now you can run `docker compose up` to start the game servers and their
+dependencies.
 
-Once you see `Duelyst 'development' started on port 3000` in the logs, the server is ready! Open
-http://localhost:3000/ in a browser to load the client, create a user, and play a practice game.
+Once you see `Duelyst 'development' started on port 3000` in the logs, the
+server is ready! Open http://localhost:3000/ in a browser to load the client,
+create a user, and play a practice game.
 
 ## Common Troubleshooting Steps <a id="troubleshooting" />
 
 After you load Duelyst in your browser, there are two key places to monitor:
 
-1. The browser console, which will relay all errors generated by the app. Filtering this to only
-the `warning` and `error` log levels will make things more readable.
+1. The browser console, which will relay all errors generated by the app.
+Filtering this to only the `warning` and `error` log levels will make things
+more readable.
 
-2. The console output of Docker Compose, which will multiplex log output from all of the game
-containers. Keep an eye out in particular for any error stack traces, which will be hard to miss
-since they span several lines and break from the typical log format.
+2. The console output of Docker Compose, which will multiplex log output from
+all of the game containers. Keep an eye out in particular for any error stack
+traces, which will be hard to miss since they span several lines and break from
+the typical log format.
 
-Errors from both of these sources should give you both a file and line number to reference. If not,
-you can generally search for the error string to find out where the error is originating in the
-code. Some errors originate from our dependencies, so you can also search for error strings in the
-`node_modules/` directory if you're having trouble tracking something down.
+Errors from both of these sources should give you both a file and line number
+to reference. If not, you can generally search for the error string to find out
+where the error is originating in the code. Some errors originate from our
+dependencies, so you can also search for error strings in the `node_modules/`
+directory if you're having trouble tracking something down.
 
 ## Making App (Frontend) Changes <a id="frontend-changes" />
 
-Now that you have the full development environment set up, you can try making changes to the game
-client. To do this, edit any code, cards, or resources desired in the `app/` directory.
+Now that you have the full development environment set up, you can try making
+changes to the game client. To do this, edit any code, cards, or resources
+desired in the `app/` directory.
 
 When finished, build the game once more:
 ```
 FIREBASE_URL=<YOUR_FIREBASE_URL> yarn build
 ```
 
-You can now run `docker compose up` again and load the client to test your changes.
+You can now run `docker compose up` again and load the client to test your
+changes.
 
 ## Making Server/Worker (Backend) Changes <a id="backend-changes" />
 
 When working on the Server or Worker code, you don't need to rebuild the game.
-Instead, simply run `docker compose up` again, and load the game client to test your changes.
+Instead, simply run `docker compose up` again, and load the game client to test
+your changes.
 
-Don't forget to run unit tests with `yarn test:unit`, and integration tests with
-`yarn test:integration`. If you notice a failing test for code you haven't changed, please file a
-new `bug` issue.
+Don't forget to run unit tests with `yarn test:unit`, and integration tests
+with `yarn test:integration`. If you notice a failing test for code you haven't
+changed, please file a new `bug` issue.
 
 ## Opening Pull Requests <a id="pull-requests" />
 
-Once you have a contribution ready, you can open a pull request to get it reviewed.
+Once you have a contribution ready, you can open a pull request to get it
+reviewed.
 
-First, fork OpenDuelyst on Github, and push your branch to the fork. Then, when signed into Github,
-you'll be prompted to open a pull request when viewing the OpenDuelyst repo.
+First, fork OpenDuelyst on Github, and push your branch to the fork. Then, when
+signed into Github, you'll be prompted to open a pull request when viewing the
+OpenDuelyst repo.
 
-If the contribution solves an open issue, you can automatically close that issue when the PR is
-merged. To do this, include the text "Closes #1234" in the PR description (to automatically close
-issue #1234).
+If the contribution solves an open issue, you can automatically close that
+issue when the PR is merged. To do this, include the text "Closes #1234" in the
+PR description (to automatically close issue #1234).
 
-When you open a pull request, some tasks will automatically start in our Continuous Integration
-(CI) environment to lint and test the code.
+When you open a pull request, some tasks will automatically start in our
+Continuous Integration (CI) environment to lint and test the code.
 
-We use [Github Actions](https://github.com/features/actions) for CI, so you can see the status
-and results of these tasks right in the pull request itself.
+We use [Github Actions](https://github.com/features/actions) for CI, so you can
+see the atatus and results of these tasks right in the pull request itself.
 
-Once the PR has been reviewed and accepted, it will be merged into the `main` branch.
-At this point, you are now an OpenDuelyst developer. Congratulations!
+Once the PR has been reviewed and accepted, it will be merged into the `main`
+branch. At this point, you are now an OpenDuelyst developer. Congratulations!
 
 ## Versioning <a id="versioning" />
 
 OpenDuelyst uses [Semantic Versioning](https://semver.org/) for its releases.
-In version `1.96.17`, `1` is the `MAJOR` version, `96` is the `MINOR` version, and `17` is the
-`PATCH` version.
+In version `1.96.17`, `1` is the `MAJOR` version, `96` is the `MINOR` version,
+and `17` is the `PATCH` version.
 
-For OpenDuelyst, the `MAJOR` version should not exceed `1`. Note that the immediate release after
-`1.99` is `1.100` and not `2.0.0`.
+For OpenDuelyst, the `MAJOR` version should not exceed `1`. Note that the
+immediate release after `1.99` is `1.100` and not `2.0.0`.
 
 ## Where to Get Help <a id="get-help" />
 
 At the moment, you can get help with OpenDuelyst by opening an issue.
-Since this is a volunteer project, it may take a few days for someone to look at your issue.
+Since this is a volunteer project, it may take a few days for someone to look
+at your issue.
 
-You can also join the [OpenDuelyst Discord server](https://discord.gg/HhUWfZ9cxe) for technical
-discussion and support.
+You can also join the [OpenDuelyst Discord server](https://discord.gg/HhUWfZ9cxe)
+for technical discussion and support.


### PR DESCRIPTION
## Summary

- Cleans up the README
- Reduces max line length to 80 in a few docs
- Copies the `LICENSE` file to `COPYING` as well, based on the CC0 recommendations [here](https://wiki.creativecommons.org/wiki/CC0_FAQ#May_I_apply_CC0_to_computer_software.3F_If_so.2C_is_there_a_recommended_implementation.3F).

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.