### PR TITLE
Adds scripts for pruning container images

### DIFF
--- a/docker/migrate.Dockerfile
+++ b/docker/migrate.Dockerfile
@@ -2,8 +2,5 @@
 ARG NODEJS_IMAGE_VERSION
 FROM duelyst-nodejs:${NODEJS_IMAGE_VERSION}
 
-# Install dev dependencies as well.
-RUN yarn install --include=dev && yarn cache clean
-
 # Start the service.
 ENTRYPOINT ["yarn", "migrate:latest"]

--- a/docker/nodejs.Dockerfile
+++ b/docker/nodejs.Dockerfile
@@ -7,6 +7,7 @@ RUN git config --global url."https://github.com/".insteadOf git@github.com:
 RUN git config --global url."https://".insteadOf git://
 
 # Add Python and other build utils for bcrypt.
+# TODO: Put this into an intermediate layer to reduce Game/Migrate/SP image size.
 RUN apk add python3 make gcc g++
 
 # Include Node.js dependencies in the image.

--- a/docker/start.sh
+++ b/docker/start.sh
@@ -9,12 +9,7 @@ git config --global url."https://".insteadOf git://
 apk add python3 make gcc g++
 
 # Install dependencies.
-if [ $1 == 'migrate:latest' ]; then
-  # Migrations code uses dev dependencies
-  yarn install --include=dev
-else
-  yarn install --production
-fi
+yarn install --production
 
 # Use exec to take over the PID from the shell, enabling signal handling.
 exec yarn $1

--- a/gulp/shop.js
+++ b/gulp/shop.js
@@ -5,7 +5,6 @@ import qs from 'querystring';
 import gulp from 'gulp';
 import gutil from 'gulp-util';
 import Promise from 'bluebird';
-import ProgressBar from 'progress';
 import colors from 'colors';
 import path from 'path';
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,6 @@
     "minimist": "^1.2.0",
     "mocha": "^10.0.0",
     "power-assert": "^1.4.1",
-    "progress": "1.1.8",
     "read-pkg": "^1.1.0",
     "rework-plugin-url": "^1.0.1",
     "sass": "^1.49.9",

--- a/scripts/prune_ecr_container_images.py
+++ b/scripts/prune_ecr_container_images.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+import boto3
+
+# Get AWS account ID.
+sts_client = boto3.client('sts')
+account_id = sts_client.get_caller_identity().get('Account')
+
+# Find untagged and non-latest ECR images.
+ecr_client = boto3.client('ecr-public')
+images_to_delete = dict()
+for svc in ['api', 'game', 'migrate', 'sp', 'worker']:
+    images_to_delete[svc] = list()
+    images = ecr_client.describe_images(
+        registryId=account_id,
+        repositoryName='duelyst-{}'.format(svc),
+    ).get('imageDetails')
+    for img in images:
+        if 'imageTags' in img.keys() and 'latest' in img.get('imageTags'):
+            continue
+        images_to_delete[svc].append(img.get('imageDigest'))
+
+# Prune ECR images.
+for svc, images in images_to_delete.items():
+    if images:
+        print('Deleting images for service {}: {}'.format(svc, images))
+        resp = ecr_client.batch_delete_image(
+            registryId=account_id,
+            repositoryName='duelyst-{}'.format(svc),
+            imageIds=[{'imageDigest': i} for i in images],
+        )
+        failures = resp.get('failures')
+        if failures:
+            print(resp.get('ResponseMetadata').get('HTTPStatusCode'))
+            print('Failures: {}'.format(failures))
+            exit(1)
+
+print('Done!')

--- a/scripts/prune_local_container_images.sh
+++ b/scripts/prune_local_container_images.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+ecr_registry_id=$1
+if [ -z $ecr_registry_id ]; then
+	echo "Usage: prune_local_container_images.sh <ECR-REGISTRY-ID>"
+	exit 1
+fi
+
+current_version=$(git tag -l | tail -1)
+echo "Pruning unused Docker images"
+echo "Preserving current version ${current_version}"
+
+# Valid versions start with '1.9'.
+local_versions=$(docker image ls | awk '{print $2}' | sort -u | grep '1\.9')
+
+for svc in api game migrate nodejs sp worker; do
+	for v in $local_versions; do
+		if [ $v == $current_version ]; then
+			continue
+		fi
+		docker rmi duelyst-${svc}:$v 2&>/dev/null
+		docker rmi public.ecr.aws/${ecr_registry_id}/duelyst-${svc}:$v 2&>/dev/null
+	done
+done
+echo "Done!"

--- a/scripts/temp/tmp_find_duplicate_users.coffee
+++ b/scripts/temp/tmp_find_duplicate_users.coffee
@@ -7,7 +7,6 @@ DuelystFirebase= require("../../server/lib/duelyst_firebase_module")
 FirebasePromises = require("../../server/lib/firebase_promises")
 _ = require 'underscore'
 Promise = require 'bluebird'
-ProgressBar = require('progress')
 Logger = require('../../app/common/logger')
 Errors = require("../../server/lib/custom_errors")
 moment = require 'moment'
@@ -46,13 +45,6 @@ return Promise.all([
   limit = allUserIds.length # Math.min(10000,userIds.length)
   console.log("#{allUserIds.length} users found")
 
-  # bar = new ProgressBar('importing users [:bar] :percent :etas', {
-  #     complete: '=',
-  #     incomplete: ' ',
-  #     width: 20,
-  #     total: limit
-  # })
-
   rootRef = @.rootRef
 
   return Promise.map(allUserIds,(userId)->
@@ -80,7 +72,6 @@ return Promise.all([
       .catch (e)->
         console.log("ERROR",e)
       .finally ()->
-        # bar?.tick()
         limit--
     else
       return Promise.resolve(true)

--- a/scripts/temp/tmp_sync_user_firebase_to_sql.coffee
+++ b/scripts/temp/tmp_sync_user_firebase_to_sql.coffee
@@ -7,7 +7,6 @@ DuelystFirebase= require("../../server/lib/duelyst_firebase_module")
 FirebasePromises = require("../../server/lib/firebase_promises")
 _ = require 'underscore'
 Promise = require 'bluebird'
-ProgressBar = require('progress')
 Logger = require('../../app/common/logger')
 Errors = require("../../server/lib/custom_errors")
 config = require('../../config/config')
@@ -57,19 +56,11 @@ return Promise.all([
 
 #   activeCodes = inviteCodesSnapshot.val()
 
-#   bar = new ProgressBar('importing invite codes [:bar] :percent :etas', {
-#       complete: '=',
-#       incomplete: ' ',
-#       width: 20,
-#       total: _.keys(activeCodes).length
-#   })
-
 #   return Promise.map(_.keys(activeCodes),(code)->
 #     return knex("invite_codes").insert({
 #       code:    code,
 #       created_at:  moment.utc(activeCodes[code].created_at).toDate()
 #     }).then ()->
-#       bar.tick()
 #   ,{concurrency:10})
 
 # .then ()->
@@ -90,13 +81,6 @@ return Promise.all([
   allUserIds = userIds
   # console.timeEnd("loaded all users")
   console.log("#{allUserIds.length} users found")
-
-  bar = new ProgressBar('importing users [:bar] :percent :etas', {
-      complete: '=',
-      incomplete: ' ',
-      width: 20,
-      total: limit
-  })
 
   authRef = @.authRef
   rootRef = @.rootRef
@@ -119,7 +103,6 @@ return Promise.all([
       .catch (e)->
         console.log("ERROR on #{userId} ... ",e)
       .finally ()->
-        bar?.tick()
         limit--
     else
       return Promise.resolve(true)

--- a/server/migrations/20151015145008_add_user_ribbons.js
+++ b/server/migrations/20151015145008_add_user_ribbons.js
@@ -5,7 +5,6 @@ const Promise = require('bluebird');
 
 // var FirebasePromises = require('../lib/firebase_promises.coffee')
 // var DuelystFirebase = require('../lib/duelyst_firebase_module.coffee')
-const ProgressBar = require('progress');
 
 exports.up = function (knex) {
   return Promise.all([
@@ -29,12 +28,6 @@ exports.up = function (knex) {
         })
       // .then(function(rootRef){
         .then(function () {
-          const bar = new ProgressBar(`migrating ${this.rows.length} records [:bar] :percent :etas`, {
-            complete: '=',
-            incomplete: ' ',
-            width: 20,
-            total: this.rows.length,
-          });
           return Promise.map(this.rows, (row) => {
             const allPromises = [];
             const ribbonCount = Math.floor(row.win_count / 100);
@@ -56,9 +49,7 @@ exports.up = function (knex) {
             updated_at: moment().utc().valueOf()
           }))
           */
-            return Promise.all(allPromises).then(() => {
-              bar.tick();
-            });
+            return Promise.all(allPromises);
           }, { concurrency: 20 });
         })
         .then(resolve)

--- a/server/migrations/20160702140711_create_cosmetics.js
+++ b/server/migrations/20160702140711_create_cosmetics.js
@@ -1,7 +1,6 @@
 require('coffeescript/register');
 const _ = require('underscore');
 const moment = require('moment');
-const ProgressBar = require('progress');
 
 exports.up = function (knex) {
   return Promise.all([

--- a/yarn.lock
+++ b/yarn.lock
@@ -11898,11 +11898,6 @@ progress-stream@^1.0.1:
     speedometer "~0.1.2"
     through2 "~0.2.3"
 
-progress@1.1.8:
-  version "1.1.8"
-  resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
-  integrity sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=
-
 promise@^7.0.1:
   version "7.3.1"
   resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"


### PR DESCRIPTION
## Summary

Closes #153.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Removes progress bar lib from migrations

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds script for pruning local Docker images
- Adds script for pruning remote ECR images

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
