### PR TITLE
Triple gold from quests

### DIFF
--- a/app/sdk/quests/questFactory.coffee
+++ b/app/sdk/quests/questFactory.coffee
@@ -56,8 +56,8 @@ class QuestFactory
   # global cache for quick access
   @_questCache: null
 
-  @SHORT_QUEST_GOLD: 50
-  @LONG_QUEST_GOLD: 100
+  @SHORT_QUEST_GOLD: 150
+  @LONG_QUEST_GOLD: 300
 
   # begin CONSTS DO NOT CHANGE # Iterate last by 100 for new quest base id
   @_FACTION_CHALLENGER_BASE_ID: 100

--- a/server/lib/data_access/quests.coffee
+++ b/server/lib/data_access/quests.coffee
@@ -42,8 +42,8 @@ class QuestsModule
   @PROMOTIONAL_QUEST_ACTIVE: true
 
   # Catch up quest reward definitions
-  @CATCH_UP_CHARGE_GOLD_VALUE:5
-  @CATCH_UP_MAX_GOLD_VALUE:25
+  @CATCH_UP_CHARGE_GOLD_VALUE: 50
+  @CATCH_UP_MAX_GOLD_VALUE: 50
 
   ###*
   # Checks if a user needs daily quests.
@@ -85,7 +85,7 @@ class QuestsModule
           # remove any quests that are no longer supposed to be in the system
           if _.contains(QuestFactory.questForIdentifier(quest.quest_type_id).types,QuestType.ExcludeFromSystem)
             return Promise.resolve(true)
-          # remove catch up quests that ended up in wrong slot, see: https://trello.com/c/3qxAtST3/1629
+          # remove catch up quests that ended up in wrong slot.
           if _.contains(QuestFactory.questForIdentifier(quest.quest_type_id).types,QuestType.CatchUp) and quest.quest_slot_index != QuestsModule.CATCH_UP_QUEST_SLOT
             return Promise.resolve(true)
 
@@ -189,7 +189,7 @@ class QuestsModule
             row.previous_quest_slot_index = row.quest_slot_index
             row.quest_slot_index = -1
             @.removedQuests.push row
-          # remove catch up quests that ended up in wrong slot, see: https://trello.com/c/3qxAtST3/1629
+          # remove catch up quests that ended up in wrong slot.
           else if _.contains(sdkQuest.types,QuestType.CatchUp) and row.quest_slot_index != QuestsModule.CATCH_UP_QUEST_SLOT
             removalQueries.push tx("user_quests").where({user_id:row.user_id,quest_slot_index:row.quest_slot_index}).delete()
             row.quest_slot_index = -1


### PR DESCRIPTION
## Summary

Missed this in #131.

**App changes (`app/`, etc.):**

- Increases gold reward for short quests from 50 to 150 (3 packs)
- Increases gold reward for long quests from 100 to 300 (6 packs)
- Changes welcome back quest from 5 gold per day (max 25) to 50 gold per day (max 50)

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
