### PR TITLE
Deploys API & Worker v1.97.5

### DIFF
--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -25,7 +25,7 @@ module "ecs_service_api" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_api.id
-  deployed_version  = "1.97.4"
+  deployed_version  = "1.97.5"
   container_count   = 1
   container_mem     = 500 # Runs out of memory with 350MB.
   service_port      = 3000
@@ -109,7 +109,7 @@ module "ecs_service_worker" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_worker.id
-  deployed_version  = "1.97.4"
+  deployed_version  = "1.97.5"
   container_count   = 1
   container_mem     = 500 # Uses about 315MB.
   enable_lb         = false


### PR DESCRIPTION
## Summary

**Infrastructure changes (`terraform/`, etc.):**

- Bumps API & Worker versions to 1.97.5
- WebSocket services are still running 1.97.4 since nothing has changed in them and I haven't built the new images yet

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to log in and complete a game locally.
