### PR TITLE
Fix worker crash

### DIFF
--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -109,7 +109,7 @@ module "ecs_service_worker" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_worker.id
-  deployed_version  = "1.97.5"
+  deployed_version  = "1.97.6-hotfix"
   container_count   = 1
   container_mem     = 500 # Uses about 315MB.
   enable_lb         = false

--- a/worker/get_gameserver.coffee
+++ b/worker/get_gameserver.coffee
@@ -2,7 +2,7 @@ Promise = require 'bluebird'
 #_ = require 'underscore'
 
 config = require '../config/config.js'
-#Logger = require '../app/common/logger.coffee'
+Logger = require '../app/common/logger.coffee'
 #Consul = require '../server/lib/consul'
 
 getGameServer = ()->


### PR DESCRIPTION
## Summary

Fixes matchmaking in staging.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Adds missing import in Worker

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Builds a hotfix container and deploys it to staging

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
