### PR TITLE
Disables staging QA routes and removes unused Firebase dependency

### DIFF
--- a/server/lib/data_access/rank.coffee
+++ b/server/lib/data_access/rank.coffee
@@ -1,6 +1,5 @@
 Promise = require 'bluebird'
 util = require 'util'
-Firebase = require 'firebase'
 glicko2 = require 'glicko2'
 
 FirebasePromises = require '../firebase_promises'

--- a/server/routes/api.coffee
+++ b/server/routes/api.coffee
@@ -59,7 +59,7 @@ router.use '/api/me/rift', meRoutes.rift
 router.use '/replays', replaysRoutes
 
 # QA / Testing
-if config.isDevelopment() || config.isStaging()
+if config.isDevelopment()
   router.use '/api/me/qa', meRoutes.qa
 
   # Just a route for secure testing

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -25,7 +25,7 @@ module "ecs_service_api" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_api.id
-  deployed_version  = "1.97.5"
+  deployed_version  = "1.97.6-hotfix"
   container_count   = 1
   container_mem     = 500 # Runs out of memory with 350MB.
   service_port      = 3000


### PR DESCRIPTION
## Summary

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Disables the QA routes in staging environments.
- Removes an unused `firebase` dependency from the server code, which was the only place it is imported outside of the frontend.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Deploys hotfix container for API to include these changes

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
