### PR TITLE
Reduces ECS-EC2 root volume size to 8GB in staging

### DIFF
--- a/terraform/modules/ecs_cluster/ec2.tf
+++ b/terraform/modules/ecs_cluster/ec2.tf
@@ -35,7 +35,7 @@ resource "aws_launch_template" "template" {
       # Given that we hardly use disks, gp3 should result in a 20% cost reduction.
       # If we ever exceed the baseline for IOPS or Throughput, let's go back to gp2.
       volume_type           = "gp3"
-      volume_size           = 30   # Default is 30GB; we only use 3GB. Need to build our own AMI to reduce this.
+      volume_size           = var.root_volume_size
       iops                  = 3000 # Cap IOPS at 3,000 to avoid overage charges.
       throughput            = 125  # Cap Throughput at 125MB/s to avoid overage charges.
       delete_on_termination = true

--- a/terraform/modules/ecs_cluster/ec2.tf
+++ b/terraform/modules/ecs_cluster/ec2.tf
@@ -16,7 +16,7 @@ locals {
 
 resource "aws_launch_template" "template" {
   name_prefix            = "ecs-${var.name}"
-  image_id               = local.ami_ids[var.architecture][data.aws_region.current.name]
+  image_id               = var.use_custom_ami ? var.custom_ami_id : local.ami_ids[var.architecture][data.aws_region.current.name]
   instance_type          = var.instance_type
   key_name               = aws_key_pair.ssh_key.id
   vpc_security_group_ids = var.security_group_ids

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -36,6 +36,12 @@ variable "instance_type" {
   default     = "t4g.micro"
 }
 
+variable "root_volume_size" {
+  type        = number
+  description = "The size of the EBS root block device on ECS-EC2 instances."
+  default     = 30
+}
+
 variable "min_capacity" {
   type        = number
   description = "The minimum number of ECS-EC2 instances."

--- a/terraform/modules/ecs_cluster/variables.tf
+++ b/terraform/modules/ecs_cluster/variables.tf
@@ -18,6 +18,18 @@ variable "architecture" {
   default     = "arm64"
 }
 
+variable "use_custom_ami" {
+  type        = bool
+  description = "Set this to true to provide your own AMI ID as var.custom_ami_id."
+  default     = false
+}
+
+variable "custom_ami_id" {
+  type        = string
+  description = "The custom AMI ID to use. Will default to ECS-optimized AMIs if not provided."
+  default     = ""
+}
+
 variable "instance_type" {
   type        = string
   description = "The instance type to use for ECS-EC2 instances."

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -1,9 +1,10 @@
 module "ecs_cluster" {
-  source         = "../modules/ecs_cluster"
-  name           = "duelyst-staging"
-  use_custom_ami = true
-  custom_ami_id  = var.custom_ami_id
-  ssh_public_key = var.ssh_public_key
+  source           = "../modules/ecs_cluster"
+  name             = "duelyst-staging"
+  use_custom_ami   = true
+  custom_ami_id    = var.custom_ami_id
+  root_volume_size = 8
+  ssh_public_key   = var.ssh_public_key
 
   # Set capacity to 3 to allow graceful deployments without stopping live containers.
   min_capacity      = 0

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -1,6 +1,8 @@
 module "ecs_cluster" {
   source         = "../modules/ecs_cluster"
   name           = "duelyst-staging"
+  use_custom_ami = true
+  custom_ami_id  = var.custom_ami_id
   ssh_public_key = var.ssh_public_key
 
   # Set capacity to 3 to allow graceful deployments without stopping live containers.

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -4,6 +4,11 @@ variable "aws_region" {
   type = string
 }
 
+variable "custom_ami_id" {
+  type    = string
+  default = ""
+}
+
 variable "aws_access_key" {
   type = string
 }

--- a/terraform/staging/variables.tf
+++ b/terraform/staging/variables.tf
@@ -1,70 +1,123 @@
 # Provide these variables in a terraform.tfvars file.
 
+# The AWS region determines where your resources will be created.
+# There is a list of available regions here:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-available-regions
 variable "aws_region" {
   type = string
 }
 
+# By default, we use Amazon's ECS-Optimized AMI.
+# You may want to use a custom image for a variety of reasons, such as reducing
+# the default disk size of 30GB.
+# To create custom AMIs, use Amazon's open source tool here:
+# https://github.com/aws/amazon-ecs-ami/
 variable "custom_ami_id" {
   type    = string
   default = ""
 }
 
+# The AWS Access Key ID for your Terraform IAM user.
+# This is only used in the provider configuration, and will not be stored in
+# the Terraform state.
 variable "aws_access_key" {
   type = string
 }
 
+# The AWS Secret Access Key for your Terraform IAM user.
+# This is only used in the provider configuration, and will not be stored in
+# the Terraform state.
 variable "aws_secret_key" {
   type = string
 }
 
+# The SSH public key to attach to your ECS-EC2 instances.
 variable "ssh_public_key" {
   type = string
 }
 
+# The S3 bucket name for storing Duelyst static assets.
+# This name must be globally unique across all of AWS.
 variable "assets_bucket_name" {
   type = string
 }
 
+# The S3 bucket name for storing Duelyst game replays.
+# This name must be globally unique across all of AWS.
 variable "replays_bucket_name" {
   type = string
 }
 
+# The domain name for the staging API service, e.g. play.duelyst.com.
 variable "staging_domain_name" {
   type = string
 }
 
+# The domain name for the CDN, e.g. cdn.duelyst.com.
 variable "cdn_domain_name" {
   type = string
 }
 
+# The first of three availability zones to use when creating AWS resources.
+# You can find a list of Availability Zones you can use by following these
+# instructions:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe
+# Note that availability zones are randomized for each AWS account. In other
+# words, us-east-1a in one account may not be the same datacenter as us-east-1a
+# in another AWS account.
 variable "first_availability_zone" {
   type = string
 }
 
+# The second of three availability zones to use when creating AWS resources.
+# You can find a list of Availability Zones you can use by following these
+# instructions:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe
+# Note that availability zones are randomized for each AWS account. In other
+# words, us-east-1a in one account may not be the same datacenter as us-east-1a
+# in another AWS account.
 variable "second_availability_zone" {
   type = string
 }
 
+# The third of three availability zones to use when creating AWS resources.
+# You can find a list of Availability Zones you can use by following these
+# instructions:
+# https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#availability-zones-describe
+# Note that availability zones are randomized for each AWS account. In other
+# words, us-east-1a in one account may not be the same datacenter as us-east-1a
+# in another AWS account.
 variable "third_availability_zone" {
   type = string
 }
 
+# The name of your Firebase project.
+# This is not the URL, but the shorthand project name e.g. "duelyst-12345".
+# This is used for Firebase authentication flows in the backend services.
 variable "firebase_project" {
   type = string
 }
 
+# The URL of your Firebase Realtime Database.
+# This must end in ".firebaseio.com/", including the trailing slash.
 variable "firebase_url" {
   type = string
 }
 
+# The name of the user to create in the RDS Postgres database instance.
+# This should match the username used in the "postgres_connection_string"
+# config value in the app.
 variable "database_user" {
   type = string
 }
 
+# The 8-character, alphanumeric ID for your public ECR registry.
+# This is used to tell ECS services where to obtain container images.
 variable "ecr_registry_id" {
   type = string
 }
 
+# Cloudwatch Alarms will be routed to this email address.
 variable "email_address_for_alarms" {
   type = string
 }


### PR DESCRIPTION
## Summary

Closes #196.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Adds support for providing a custom AMI ID.
- Adds support for specifying a non-default root volume size.
- Starts using a custom AMI in staging.
- Reduces the root volume size to 8GB in staging (requires custom AMI).
- Adds documentation to `variables.tf`.

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
