### PR TITLE
Ensure LF line endings for shell scripts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 * text=auto
+*.sh text eol=lf


### PR DESCRIPTION
## Summary

This should help us avoid requiring users to set `core.eol=lf` in Windows git settings.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds `*.sh text eol=lf` to `.gitattributes`

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
