### PR TITLE
Cleans up infra config and docs

### DIFF
--- a/docs/infrastructure/COSTS.md
+++ b/docs/infrastructure/COSTS.md
@@ -22,7 +22,7 @@ concurrent users:
 
 ## AWS Service Requirements
 
-Running a staging environment in AWS costs about $6/month, with the following
+Running a staging environment in AWS costs about $8/month, with the following
 breakdown:
 
 ### RDS and ElastiCache ($0/mo with Free Tier)
@@ -96,12 +96,22 @@ works well with our API and Worker services, but 2 minutes is generally not
 long enough to allow in-progress games to finish. However, we can use Spot
 instances in staging, where losing games is not a big deal.
 
-In terms of storage, EC2 provides 30GB of `gp3` disk storage for free. We don't
-have any real storage requirements for the apps, so we won't incur any
-significant storage costs.
-
 In summary, running two `t4g.micro` Spot instances to power a staging ECS
 cluster would cost about $4 per month.
+
+### EBS Storage Pricing ($2/mo)
+
+In terms of storage, EC2 provides 30GB of `gp3` disk storage for free. We don't
+have any real storage requirements for the apps, so we won't incur any
+significant storage costs for EBS volumes.
+
+The default AWS ECS-Optimized AMI specifies a 30GB root volume, which increases
+the storage costs based on how many instances we run. AWS offers a way to pack
+our own AMI based on theirs via https://github.com/aws/amazon-ecs-ami, so we
+can build custom images with an 8GB root volume instead. With two running
+instances, this reduces our `gp3` EBS costs from 60GB * $0.08 = $4.80/mo to
+16GB * $0.08 = $1.28/mo. However, this means we also need to retain an 8GB
+snapshot backing the AMI, which costs 8GB * $0.05 = $0.40/mo.
 
 ### Networking ($0/month with Free Tier)
 

--- a/docs/infrastructure/COSTS.md
+++ b/docs/infrastructure/COSTS.md
@@ -22,7 +22,7 @@ concurrent users:
 
 ## AWS Service Requirements
 
-Running a staging environment in AWS costs about $8/month, with the following
+Running a staging environment in AWS costs about $9/month, with the following
 breakdown:
 
 ### RDS and ElastiCache ($0/mo with Free Tier)
@@ -154,3 +154,8 @@ KMS, which charges a fee of $1 per month per key.
 An alternative here is AWS Secrets Manager, which charges $0.40 per secret per
 month. With five secrets, this is already twice the cost of using KMS and AWS
 SSM.
+
+### Alarms: Cloudwatch ($1/month)
+
+The first 10 Cloudwatch Alarms in an AWS account are always free. We have about
+20 alarms, so we pay for 10 of these at a rate of $0.10/month ($1/mo total).

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -40,7 +40,6 @@ module "ecs_service_api" {
     { name = "FIREBASE_URL", value = var.firebase_url },
     { name = "FIREBASE_PROJECT_ID", value = var.firebase_project },
     { name = "CDN_DOMAIN_NAME", value = var.cdn_domain_name },
-    { name = "ALL_CARDS_AVAILABLE", value = true },
     { name = "DEFAULT_GAME_SERVER", value = var.staging_domain_name },
     { name = "S3_REPLAYS_BUCKET", value = var.replays_bucket_name }
   ]


### PR DESCRIPTION
## Summary

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Removes unused environment variable for API service
- Adds EBS costs to docs
- Adds Cloudwatch costs to docs

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
