### PR TITLE
Gauntlet fix

### DIFF
--- a/app/sdk/playModes/playModeFactory.coffee
+++ b/app/sdk/playModes/playModeFactory.coffee
@@ -87,7 +87,6 @@ class PlayModeFactory
         enabled: true
         isHiddenInUI: false
         # availableOnDaysOfWeek: [0,3,5,6] # 0-6 indexed Sun-Sat
-        gamesRequiredToUnlock: 20
       }
 
       pm[PlayModes.Rift] = {


### PR DESCRIPTION
Remove 20 games to unlock requirement for Gauntlet mode.
Closes #206 

## Summary

Describe your changes here. Remove any inapplicable sections.

**App changes (`app/`, etc.):**

app/sdk/playModes/playModeFactory.coffee
- Remove gamesRequiredToUnlock field on Gauntlet mode.

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [Y ] Starting backend services locally with `docker compose up` succeeds.
- [ Y] I am able to create a new user and log in locally.
- [ Y] I am able to complete a practice game locally.
