### PR TITLE
Validate Firebase URL in app builds

### DIFF
--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -51,3 +51,5 @@ jobs:
 
     - name: build the app
       run: yarn build
+      env:
+        FIREBASE_URL: "https://test-url.firebaseio.com/"

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -67,4 +67,4 @@ jobs:
         REDIS_HOST: redis
         POSTGRES_CONNECTION: "pg://duelyst:duelyst@db/duelyst"
         # TODO: Create a Firebase Realtime Database for CI.
-        FIREBASE_URL: ""
+        FIREBASE_URL: "https://test-url.firebaseio.com/"

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -133,7 +133,13 @@ gulp.task('autowatch', (cb) => {
 */
 
 // Define aliases for task groupings
-gulp.task('source', gulp.series(gulp.parallel('vendor', 'css', 'html'), 'localization:copy', 'rsx:packages', 'js'));
+gulp.task('source', gulp.series(
+  validateFirebase,
+  gulp.parallel('vendor', 'css', 'html'),
+  'localization:copy',
+  'rsx:packages',
+  'js',
+));
 gulp.task('build', gulp.series(
   'clean:all',
   'source',
@@ -149,6 +155,7 @@ gulp.task('build:withallrsx', gulp.series(
   // 'autowatch',
 ));
 gulp.task('build:app', gulp.series(
+  validateFirebase,
   'clean:app',
   'js',
 ));
@@ -174,6 +181,17 @@ gulp.task('default', gulp.series('build'));
 
 // Release Builds (CI ready tasks)
 const ciTargets = ['staging', 'production'];
+
+function validateFirebase(cb) {
+  // Ensure FIREBASE_URL is set and valid when building the app.
+  if (process.env.FIREBASE_URL === undefined) {
+    return cb(new Error('FIREBASE_URL must be set'));
+  }
+  if (!process.env.FIREBASE_URL.endsWith('firebaseio.com/')) {
+    return cb(new Error('FIREBASE_URL must end in firebaseio.com/'));
+  }
+  return cb();
+}
 
 function validateConfig(cb) {
   // Ensure running build:release:${target} matches running config environemnt


### PR DESCRIPTION
## Summary

Closes #207.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Ensures `FIREBASE_URL` is set and ends in `firebaseio.com/`

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
