### PR TITLE
Refactors WebSocket connections from app

### DIFF
--- a/app/sdk/gameType.coffee
+++ b/app/sdk/gameType.coffee
@@ -1,10 +1,9 @@
 class GameType
-
   @Ranked: "ranked"
   @Casual: "casual"
   @Gauntlet: "gauntlet"
-  @Friendly: "friendly"
-  @Challenge: "challenge"
+  @Friendly: "friendly" # Friend Challenge
+  @Challenge: "challenge" # Solo Challenge
   @Sandbox: "sandbox"
   @SinglePlayer: "single_player"
   @Rift: "rift"

--- a/server/middleware/basic.coffee
+++ b/server/middleware/basic.coffee
@@ -20,13 +20,15 @@ if config.isDevelopment() or config.isStaging()
 else
   parser = bodyParser.json()
 
-# Enable CORS to CDN in staging/production.
-cdnDomain = config.get('aws.cdnDomainName')
-if cdnDomain && !config.isDevelopment()
-  # Same-Origin requests are already allowed; add CDN origin as well.
-  corsOptions = {origin: "https://#{cdnDomain}"}
+# Configure CORS.
+if config.isDevelopment()
+  corsOptions = {origin: "*"} # Allow any origin.
 else
-  corsOptions = {}
+  cdnDomain = config.get('aws.cdnDomainName')
+  if cdnDomain
+    corsOptions = {origin: "https://#{cdnDomain}"} # Allow CORS to CDN.
+  else
+    corsOptions = {} # Same-Origin only.
 
 module.exports = compose([
   getRealIp(),


### PR DESCRIPTION
## Summary

Still testing this out, but this should resolve the routing for various game modes in both development and staging.

Closes #143.
Closes #210.

**App changes (`app/`, etc.):**

- Refactors `app/sdk/networkManager` to improve determination of WebSocket protocols, hosts, and ports

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
