### PR TITLE
126 fix(scripts): fix regular expressions for RSX resources scan

### DIFF
--- a/scripts/generate_packages.js
+++ b/scripts/generate_packages.js
@@ -76,9 +76,9 @@
         if (/RSX\[/.test(match)) {
           isDynamic = true;
           // filter for partials that begin with a set of quotes
-          partials = p1.match(/"(?:[^"])*"|'(?:[^'])*'/g) || [];
+          partials = p1.match(/"(?:[^"])*"|'(?:[^'])*'|\}(.*?)\$\{|\}(.*?)\`|\`(.*?)\$\{/g) || [];
           partialAtBeginning = partials.length <= 1;
-          partials = _.map(partials, (partial) => partial.replace(/["']/g, ''));
+          partials = _.map(partials, (partial) => partial.replace(/["'`}]|(\$\{)/g, ''));
           partials = _.reject(partials, (partial) => !partial || partial.length < 2 || !isNaN(parseInt(partial)));
         } else {
           isDynamic = false;
@@ -287,8 +287,8 @@
 
     // look for resources in file
     const resourcesData = resourcesForFile(file, content);
-    const { resources } = resourcesData;
-    const { dynamicResources } = resourcesData;
+    const { resources, dynamicResources } = resourcesData;
+
     if (resources.length > 0 || dynamicResources.length > 0) {
       const allResources = [].concat(resources, dynamicResources);
       addPkgResources('all', allResources);


### PR DESCRIPTION
## Summary

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**
After updating code syntax to the modern with string literals previous regular expressions stoped working.

It was looking for stringified properties like ["string" + anything + "string"].
Instead of this we now have `string${anything}string`.
So related regular expressions were updated to match this change.

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [X] Starting backend services locally with `docker compose up` succeeds.
- [X] I am able to create a new user and log in locally.
- [X] I am able to complete a practice game locally.
