### PR TITLE
Deploys 1.97.8 to staging

### DIFF
--- a/scripts/release_containers.sh
+++ b/scripts/release_containers.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+version=$1
+registry=$2
+if [ -z $version ] || [ -z $registry ]; then
+	echo "Usage: release_containers.sh <verison> <ecr-registry-id>"
+	exit 1
+fi
+
+if [ $(basename $(pwd)) != 'duelyst' ]; then
+	echo "Run this from the repo root."
+	exit 1
+fi
+
+for svc in api game migrate sp worker; do
+	./scripts/build_container.sh $svc $version
+	./scripts/publish_container.sh $svc $version $registry
+done

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -28,7 +28,7 @@ module "ecs_service_api" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_api.id
-  deployed_version  = "1.97.7"
+  deployed_version  = "1.97.8"
   container_count   = 1
   container_mem     = 450
   service_port      = 3000
@@ -60,7 +60,7 @@ module "ecs_service_game" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_game.id
-  deployed_version  = "1.97.7"
+  deployed_version  = "1.97.8"
   container_count   = 1
   container_mem     = 350
   service_port      = 8001
@@ -86,7 +86,7 @@ module "ecs_service_sp" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_sp.id
-  deployed_version  = "1.97.7"
+  deployed_version  = "1.97.8"
   container_count   = 1
   container_mem     = 350
   service_port      = 8000
@@ -111,7 +111,7 @@ module "ecs_service_worker" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_worker.id
-  deployed_version  = "1.97.7"
+  deployed_version  = "1.97.8"
   container_count   = 1
   container_mem     = 450
   enable_lb         = false
@@ -143,7 +143,7 @@ module "ecs_service_migrate" {
   task_role         = module.ecs_cluster.task_role
   ecr_registry      = var.ecr_registry_id
   ecr_repository    = module.ecr_repository_migrate.id
-  deployed_version  = "1.97.7"
+  deployed_version  = "1.97.8"
   container_count   = 0 # Change to 1 to apply database migrations.
   container_mem     = 350
   enable_lb         = false


### PR DESCRIPTION
## Summary

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds a helper script for building and publishing container images for all services at once.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Deploys v1.97.8 to all ECS services in staging.

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
