### PR TITLE
Adds preliminary support for playing on mobile web

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,15 @@ Desktop clients for Windows, Mac, and Linux can be downloaded on the
 Desktop clients currently use the staging environment. They'll use the
 production environment once it's available.
 
+## Playing on Android or iOS
+
+We have basic support for playing on mobile web currently. From your phone's
+browser, head to https://staging.duelyst.org to try it out.
+
+To hide the status/navigation bar in Chrome or Safari, open the game and select
+"Add to Home Screen". When you open the game from the home screen, the status
+bar will be hidden.
+
 ## Contributing to OpenDuelyst
 
 If you'd like to contribute to OpenDuelyst, check out our

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -12,7 +12,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/Guide/Mobile -->
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag -->
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=0.1, maximum-scale=1.0, user-scalable=no">
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
     <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -8,17 +8,29 @@
     <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
     <meta name="description" content="">
 
-    <!-- Needs work -->
+    <!-- Mobile web configuration below -->
+    <!-- https://developer.mozilla.org/en-US/docs/Web/Guide/Mobile -->
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta -->
+
+    <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag -->
     <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
     <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
     <!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
-    <!-- We don't appear to use the orientation API from CSS -->
-    <!-- That said, Cocos2D may attempt to read orientation to support rotation -->
+    <!-- We don't use the orientation API from CSS -->
+    <!-- Cocos2D may attempt to read orientation to support rotation -->
     <meta name="screen-orientation" content="portrait"/>
 
-    <!-- TODO: Non-Apple settings? -->
+    <!-- Progressive Web App settings -->
+    <!-- https://en.wikipedia.org/wiki/Progressive_web_app -->
+    <!-- https://web.dev/native-hardware-fullscreen/#launching-a-page-fullscreen-from-home-screen -->
+    <!-- See also: https://developer.chrome.com/blog/pwacompat/ -->
+    <!-- This setting hides the status/navigation bar on Chrome apps -->
+    <meta name="mobile-web-app-capable" content="yes"/>
+    <!-- This setting hides the status/navigation bar on Safari apps -->
+    <!-- https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html -->
+    <!-- This appears to possibly be deprecated, with archived documentation -->
     <meta name="apple-mobile-web-app-capable" content="yes"/>
 
     <meta name="msapplication-tap-highlight" content="no">

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -1,66 +1,66 @@
 <!DOCTYPE html>
 <html>
-		<head>
-				<meta charset="utf-8">
-				<meta http-equiv="X-UA-Compatible" content="IE=edge">
-				<title>DUELYST</title>
-				<link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
-				<link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
-				<meta name="description" content="">
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>DUELYST</title>
+        <link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
+        <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
+        <meta name="description" content="">
 
-				<!-- Needs work -->
-				<meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <!-- Needs work -->
+        <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-				<!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
-				<!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
-				<!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
-				<!-- We don't appear to use the orientation API from CSS -->
-				<!-- That said, Cocos2D may attempt to read orientation to support rotation -->
-				<meta name="screen-orientation" content="portrait"/>
+        <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
+        <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
+        <!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
+        <!-- We don't appear to use the orientation API from CSS -->
+        <!-- That said, Cocos2D may attempt to read orientation to support rotation -->
+        <meta name="screen-orientation" content="portrait"/>
 
-				<!-- TODO: Non-Apple settings? -->
-				<meta name="apple-mobile-web-app-capable" content="yes"/>
+        <!-- TODO: Non-Apple settings? -->
+        <meta name="apple-mobile-web-app-capable" content="yes"/>
 
-				<meta name="msapplication-tap-highlight" content="no">
-				<meta name="full-screen" content="yes"/>
-				<meta name="x5-fullscreen" content="true"/>
+        <meta name="msapplication-tap-highlight" content="no">
+        <meta name="full-screen" content="yes"/>
+        <meta name="x5-fullscreen" content="true"/>
 
-				<script type="text/javascript">
-					// this is for cocos
-					window.ccMapLimit = 100
-				</script>
+        <script type="text/javascript">
+          // this is for cocos
+          window.ccMapLimit = 100
+        </script>
 
-				<link rel="stylesheet" href="duelyst.css">
+        <link rel="stylesheet" href="duelyst.css">
 
-		</head>
-		<body>
+    </head>
+    <body>
 
-		<!-- application container div -->
-		<div id="app">
-		<div id="app-main">
-					<div id="app-horizontal">
-					<canvas id="app-gamecanvas"></canvas>
-					<div id="app-content-region"></div>
-					<div id="app-utility-region"></div>
-					</div>
-			<div id="app-vertical">
-				<div id="app-modal-region"></div>
-				<div id="app-notifications-region"></div>
-			</div>
-		</div>
-		<div id="app-overlay-region"></div>
-		<div id="maintenance-announcements-region"></div>
-		<div id="app-preloading">
-			<div class="brand-main">
-				<h1>DUELYST</h1>
-			</div>
-			<img class="mystic-loader" src="loading.gif">
-		</div>
-		</div>
-		<!-- end container div -->
+    <!-- application container div -->
+    <div id="app">
+    <div id="app-main">
+          <div id="app-horizontal">
+          <canvas id="app-gamecanvas"></canvas>
+          <div id="app-content-region"></div>
+          <div id="app-utility-region"></div>
+          </div>
+      <div id="app-vertical">
+        <div id="app-modal-region"></div>
+        <div id="app-notifications-region"></div>
+      </div>
+    </div>
+    <div id="app-overlay-region"></div>
+    <div id="maintenance-announcements-region"></div>
+    <div id="app-preloading">
+      <div class="brand-main">
+        <h1>DUELYST</h1>
+      </div>
+      <img class="mystic-loader" src="loading.gif">
+    </div>
+    </div>
+    <!-- end container div -->
 
-		<script src="vendor.js" crossorigin></script>
-		<script src="duelyst.js" crossorigin></script>
+    <script src="vendor.js" crossorigin></script>
+    <script src="duelyst.js" crossorigin></script>
 
-		</body>
+    </body>
 </html>

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -7,9 +7,20 @@
 				<link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
 				<link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
 				<meta name="description" content="">
+
+				<!-- Needs work -->
 				<meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+
+				<!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
+				<!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
+				<!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
+				<!-- We don't appear to use the orientation API from CSS -->
+				<!-- That said, Cocos2D may attempt to read orientation to support rotation -->
 				<meta name="screen-orientation" content="portrait"/>
+
+				<!-- TODO: Non-Apple settings? -->
 				<meta name="apple-mobile-web-app-capable" content="yes"/>
+
 				<meta name="msapplication-tap-highlight" content="no">
 				<meta name="full-screen" content="yes"/>
 				<meta name="x5-fullscreen" content="true"/>
@@ -19,7 +30,6 @@
 					window.ccMapLimit = 100
 				</script>
 
-				<!-- DUELYST CSS HERE ++ -->
 				<link rel="stylesheet" href="duelyst.css">
 
 		</head>
@@ -49,7 +59,6 @@
 		</div>
 		<!-- end container div -->
 
-		<!-- DUELYST JS HERE ++ -->
 		<script src="vendor.js" crossorigin></script>
 		<script src="duelyst.js" crossorigin></script>
 

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -1,66 +1,64 @@
 <!DOCTYPE html>
 <html>
-    <head>
-        <meta charset="utf-8">
-        <meta http-equiv="X-UA-Compatible" content="IE=edge">
-        <title>DUELYST</title>
-        <link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
-        <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
-        <meta name="description" content="">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <title>DUELYST</title>
+    <link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
+    <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
+    <meta name="description" content="">
 
-        <!-- Needs work -->
-        <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <!-- Needs work -->
+    <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
-        <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
-        <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
-        <!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
-        <!-- We don't appear to use the orientation API from CSS -->
-        <!-- That said, Cocos2D may attempt to read orientation to support rotation -->
-        <meta name="screen-orientation" content="portrait"/>
+    <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
+    <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->
+    <!-- https://developer.mozilla.org/en-US/docs/Web/API/Screen/orientation#browser_compatibility -->
+    <!-- We don't appear to use the orientation API from CSS -->
+    <!-- That said, Cocos2D may attempt to read orientation to support rotation -->
+    <meta name="screen-orientation" content="portrait"/>
 
-        <!-- TODO: Non-Apple settings? -->
-        <meta name="apple-mobile-web-app-capable" content="yes"/>
+    <!-- TODO: Non-Apple settings? -->
+    <meta name="apple-mobile-web-app-capable" content="yes"/>
 
-        <meta name="msapplication-tap-highlight" content="no">
-        <meta name="full-screen" content="yes"/>
-        <meta name="x5-fullscreen" content="true"/>
+    <meta name="msapplication-tap-highlight" content="no">
+    <meta name="full-screen" content="yes"/>
+    <meta name="x5-fullscreen" content="true"/>
 
-        <script type="text/javascript">
-          // this is for cocos
-          window.ccMapLimit = 100
-        </script>
+    <script type="text/javascript">
+      // this is for cocos
+      window.ccMapLimit = 100
+    </script>
 
-        <link rel="stylesheet" href="duelyst.css">
+    <link rel="stylesheet" href="duelyst.css">
+  </head>
 
-    </head>
-    <body>
-
+  <body>
     <!-- application container div -->
     <div id="app">
-    <div id="app-main">
-          <div id="app-horizontal">
+      <div id="app-main">
+        <div id="app-horizontal">
           <canvas id="app-gamecanvas"></canvas>
           <div id="app-content-region"></div>
           <div id="app-utility-region"></div>
-          </div>
-      <div id="app-vertical">
-        <div id="app-modal-region"></div>
-        <div id="app-notifications-region"></div>
+        </div>
+        <div id="app-vertical">
+          <div id="app-modal-region"></div>
+          <div id="app-notifications-region"></div>
+        </div>
       </div>
-    </div>
-    <div id="app-overlay-region"></div>
-    <div id="maintenance-announcements-region"></div>
-    <div id="app-preloading">
-      <div class="brand-main">
-        <h1>DUELYST</h1>
+      <div id="app-overlay-region"></div>
+      <div id="maintenance-announcements-region"></div>
+      <div id="app-preloading">
+        <div class="brand-main">
+          <h1>DUELYST</h1>
+        </div>
+        <img class="mystic-loader" src="loading.gif">
       </div>
-      <img class="mystic-loader" src="loading.gif">
-    </div>
     </div>
     <!-- end container div -->
 
     <script src="vendor.js" crossorigin></script>
     <script src="duelyst.js" crossorigin></script>
-
-    </body>
+  </body>
 </html>

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -8,9 +8,8 @@
     <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
     <meta name="description" content="">
 
-    <!-- Mobile web configuration below -->
+    <!-- Mobile web configuration -->
     <!-- https://developer.mozilla.org/en-US/docs/Web/Guide/Mobile -->
-    <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta -->
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag -->
     <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
@@ -28,10 +27,13 @@
     <!-- See also: https://developer.chrome.com/blog/pwacompat/ -->
     <!-- This setting hides the status/navigation bar on Chrome apps -->
     <meta name="mobile-web-app-capable" content="yes"/>
+
     <!-- This setting hides the status/navigation bar on Safari apps -->
     <!-- https://developer.apple.com/library/archive/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html -->
     <!-- This appears to possibly be deprecated, with archived documentation -->
     <meta name="apple-mobile-web-app-capable" content="yes"/>
+
+    <!-- End mobile web configuration -->
 
     <meta name="msapplication-tap-highlight" content="no">
     <meta name="full-screen" content="yes"/>

--- a/app/index.hbs
+++ b/app/index.hbs
@@ -12,7 +12,7 @@
     <!-- https://developer.mozilla.org/en-US/docs/Web/Guide/Mobile -->
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/HTML/Viewport_meta_tag -->
-    <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
 
     <!-- https://developer.mozilla.org/en-US/docs/Web/API/CSS_Object_Model/Managing_screen_orientation -->
     <!-- Note: The orientation API may not be supported by Safari on Mac/iOS -->

--- a/app/index.register.hbs
+++ b/app/index.register.hbs
@@ -1,96 +1,96 @@
 <!DOCTYPE html>
 <html>
-		<head>
-				<meta charset="utf-8">
-				<meta http-equiv="X-UA-Compatible" content="IE=edge">
-				<title>DUELYST</title>
-				<link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
-				<link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
-				<meta name="description" content="">
-				<meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
-				<meta name="screen-orientation" content="portrait"/>
-				<meta name="apple-mobile-web-app-capable" content="yes"/>
-				<meta name="msapplication-tap-highlight" content="no">
-				<meta name="full-screen" content="yes"/>
-				<meta name="x5-fullscreen" content="true"/>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>DUELYST</title>
+        <link rel="icon" type="image/gif" href="{{window.location.origin}}/favicon.gif">
+        <link rel="shortcut icon" href="{{window.location.origin}}/favicon.ico">
+        <meta name="description" content="">
+        <meta name="viewport" content="width=800, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+        <meta name="screen-orientation" content="portrait"/>
+        <meta name="apple-mobile-web-app-capable" content="yes"/>
+        <meta name="msapplication-tap-highlight" content="no">
+        <meta name="full-screen" content="yes"/>
+        <meta name="x5-fullscreen" content="true"/>
 
-				<script type="text/javascript">
-					// this is for cocos
-					window.ccMapLimit = 100
-				</script>
+        <script type="text/javascript">
+          // this is for cocos
+          window.ccMapLimit = 100
+        </script>
 
-				<!-- DUELYST CSS HERE ++ -->
-				<link rel="stylesheet" href="duelyst.css">
+        <!-- DUELYST CSS HERE ++ -->
+        <link rel="stylesheet" href="duelyst.css">
 
-				{{#if analyticsEnabled}}
-				<!-- Google Analytics initialization code-->
-				<script>
-					(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-							(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-									m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-					})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        {{#if analyticsEnabled}}
+        <!-- Google Analytics initialization code-->
+        <script>
+          (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+              (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+                  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+          })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
-					if (window.isDesktop) {
-						var uuid = window.uuid
-						if (!localStorage["gaClientId"])
-							localStorage.setItem("gaClientId",uuid.v4())
-						var clientId = localStorage["gaClientId"];
-						ga('create', "{{gaId}}",{
-							'storage': 'none',
-							'clientId': clientId
-						});
-						ga('set', 'checkProtocolTask', function(){}); // Disable file protocol checking.
-					} else {
-						ga('create', "{{gaId}}", 'auto');
-					}
-					ga('send', 'pageview');
-				</script>
-				{{/if}}
-		</head>
-		<body>
+          if (window.isDesktop) {
+            var uuid = window.uuid
+            if (!localStorage["gaClientId"])
+              localStorage.setItem("gaClientId",uuid.v4())
+            var clientId = localStorage["gaClientId"];
+            ga('create', "{{gaId}}",{
+              'storage': 'none',
+              'clientId': clientId
+            });
+            ga('set', 'checkProtocolTask', function(){}); // Disable file protocol checking.
+          } else {
+            ga('create', "{{gaId}}", 'auto');
+          }
+          ga('send', 'pageview');
+        </script>
+        {{/if}}
+    </head>
+    <body>
 
-		<!-- application container div -->
-		<div id="app">
-		<div id="app-main">
-					<div id="app-horizontal">
-					<canvas id="app-gamecanvas"></canvas>
-					<div id="app-content-region"></div>
-					<div id="app-utility-region"></div>
-					</div>
-			<div id="app-vertical">
-				<div id="app-modal-region"></div>
-				<div id="app-notifications-region"></div>
-			</div>
-		</div>
-		<div id="app-overlay-region"></div>
-		<div id="maintenance-announcements-region"></div>
-		<div id="app-preloading">
-			<div class="brand-main">
-				<h1>DUELYST</h1>
-			</div>
-			<img class="mystic-loader" src="loading.gif">
-		</div>
-		</div>
-		<!-- end container div -->
+    <!-- application container div -->
+    <div id="app">
+    <div id="app-main">
+          <div id="app-horizontal">
+          <canvas id="app-gamecanvas"></canvas>
+          <div id="app-content-region"></div>
+          <div id="app-utility-region"></div>
+          </div>
+      <div id="app-vertical">
+        <div id="app-modal-region"></div>
+        <div id="app-notifications-region"></div>
+      </div>
+    </div>
+    <div id="app-overlay-region"></div>
+    <div id="maintenance-announcements-region"></div>
+    <div id="app-preloading">
+      <div class="brand-main">
+        <h1>DUELYST</h1>
+      </div>
+      <img class="mystic-loader" src="loading.gif">
+    </div>
+    </div>
+    <!-- end container div -->
 
-		<!-- DUELYST JS HERE ++ -->
-		<script src="vendor.js" crossorigin></script>
-		<script src="register.js" crossorigin></script>
+    <!-- DUELYST JS HERE ++ -->
+    <script src="vendor.js" crossorigin></script>
+    <script src="register.js" crossorigin></script>
 
-		{{#if zendeskEnabled}}
-		<!-- Start of duelystsupport Zendesk Widget script -->
-		<script>/*<![CDATA[*/window.zEmbed = function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function()
-		{a.push(arguments)}
-		,window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try
-		{o=s}
-		catch(e)
-		{n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}
-		o.open()._l=function()
-		{var e=this.createElement("script");n&&(this.domain=n),e.id="js-iframe-async",e.src="https://assets.zendesk.com/embeddable_framework/main.js",this.t=+new Date,this.zendeskHost="duelystsupport.zendesk.com",this.zEQueue=a,this.body.appendChild(e)}
-		,o.write('<body onload="document._l();">'),o.close()};
-		/*]]>*/</script>
-		<!-- End of duelystsupport Zendesk Widget script -->
-		{{/if}}
+    {{#if zendeskEnabled}}
+    <!-- Start of duelystsupport Zendesk Widget script -->
+    <script>/*<![CDATA[*/window.zEmbed = function(e,t){var n,o,d,i,s,a=[],r=document.createElement("iframe");window.zEmbed=function()
+    {a.push(arguments)}
+    ,window.zE=window.zE||window.zEmbed,r.src="javascript:false",r.title="",r.role="presentation",(r.frameElement||r).style.cssText="display: none",d=document.getElementsByTagName("script"),d=d[d.length-1],d.parentNode.insertBefore(r,d),i=r.contentWindow,s=i.document;try
+    {o=s}
+    catch(e)
+    {n=document.domain,r.src='javascript:var d=document.open();d.domain="'+n+'";void(0);',o=s}
+    o.open()._l=function()
+    {var e=this.createElement("script");n&&(this.domain=n),e.id="js-iframe-async",e.src="https://assets.zendesk.com/embeddable_framework/main.js",this.t=+new Date,this.zendeskHost="duelystsupport.zendesk.com",this.zEQueue=a,this.body.appendChild(e)}
+    ,o.write('<body onload="document._l();">'),o.close()};
+    /*]]>*/</script>
+    <!-- End of duelystsupport Zendesk Widget script -->
+    {{/if}}
 
-		</body>
+    </body>
 </html>


### PR DESCRIPTION
## Summary

This has already been deployed to https://staging.duelyst.org as a one-off. There are still a few remaining issues (see #220 and #221), but this makes things playable!

Closes #109.

**App changes (`app/`, etc.):**

- Changes viewport width from 800 to `device-width` to enable automatic scaling
- Reduces initial viewport scale from 1.0 to 0.1 (the minimum) which allows devices to scale up to their resolution
- Adds support for hiding the status/navigation bar in Google Chrome "Add to Home Screen" apps
- Updates docs

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
