### PR TITLE
Disable Redis persistence

### DIFF
--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -57,6 +57,7 @@ resource "aws_ecs_task_definition" "task_def" {
       essential   = true
       cpu         = var.container_cpu
       memory      = var.container_mem
+      command     = var.command == [] ? null : var.command
       mountPoints = []
       volumesFrom = []
       portMappings = var.service_port == 0 ? [] : [{

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -47,6 +47,12 @@ variable "container_mem" {
   default     = 350 # Allows for 2 containers on a t4g.micro instance.
 }
 
+variable "command" {
+  type        = list(string)
+  description = "A custom command to run in the container image."
+  default     = []
+}
+
 variable "service_port" {
   type        = number
   description = "The TCP port to expose via `portMapping` for this service. Disabled by default."

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -158,6 +158,7 @@ module "ecs_service_redis" {
   deployed_version  = "6"
   container_count   = 1
   container_mem     = 450
+  command           = ["redis-server", "--save", "\"\"", "--appendonly", "no"] # Disable persistence.
   service_port      = 6379
   network_mode      = "awsvpc"
   security_groups   = [module.internal_security_group.id]


### PR DESCRIPTION
## Summary

Our Redis data is transient, so this helps reduce resource utilization and log spam.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Adds support for custom commands in ECS tasks
- Uses custom commands to disable Redis persistence

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
