### PR TITLE
Adds disabled Postgres ECS service

### DIFF
--- a/terraform/modules/ecs_cluster/iam.tf
+++ b/terraform/modules/ecs_cluster/iam.tf
@@ -9,19 +9,19 @@ resource "aws_iam_role" "ecs_instance_role" {
 
   assume_role_policy = <<EOF
 {
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Action": "sts:AssumeRole",
-            "Principal": {
-               "Service": "ec2.amazonaws.com"
-            },
-            "Effect": "Allow",
-            "Sid": ""
-        }
-    ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
 }
-EOF	
+EOF
 }
 
 # Create an instance profile for the instances.
@@ -40,7 +40,7 @@ resource "aws_iam_policy" "s3_upload_policy" {
     {
       "Action": [
         "s3:PutObject",
-				"s3:PutObjectAcl"
+        "s3:PutObjectAcl"
       ],
       "Effect": "Allow",
       "Resource": "*"
@@ -67,6 +67,50 @@ resource "aws_iam_role_policy_attachment" "ecs_instance_cw_policy_attachment" {
   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
   role       = aws_iam_role.ecs_instance_role.name
 }
+
+# Create a policy which allows managing EBS devices.
+/* Disabled: Was used for testing rexray/ebs Docker plugin.
+resource "aws_iam_policy" "ebs_management_policy" {
+  name   = "EBSManager"
+  policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:AttachVolume",
+        "ec2:CreateVolume",
+        "ec2:CreateSnapshot",
+        "ec2:CreateTags",
+        "ec2:DeleteVolume",
+        "ec2:DeleteSnapshot",
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeInstances",
+        "ec2:DescribeVolumes",
+        "ec2:DescribeVolumeAttribute",
+        "ec2:DescribeVolumeStatus",
+        "ec2:DescribeSnapshots",
+        "ec2:CopySnapshot",
+        "ec2:DescribeSnapshotAttribute",
+        "ec2:DetachVolume",
+        "ec2:ModifySnapshotAttribute",
+        "ec2:ModifyVolumeAttribute",
+        "ec2:DescribeTags"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+EOF
+}
+
+# Attach the EBS management policy to the instance role.
+resource "aws_iam_role_policy_attachment" "ecs_instance_ebs_policy_attachment" {
+  policy_arn = aws_iam_policy.ebs_management_policy.arn
+  role       = aws_iam_role.ecs_instance_role.name
+}
+*/
 
 #
 # Task Role & Policy

--- a/terraform/modules/ecs_service/main.tf
+++ b/terraform/modules/ecs_service/main.tf
@@ -50,6 +50,29 @@ resource "aws_ecs_task_definition" "task_def" {
   requires_compatibilities = []
   tags                     = {}
 
+  dynamic "placement_constraints" {
+    for_each = var.placement_constraints
+    content {
+      type       = placement_constraints.value.type
+      expression = placement_constraints.value.expression
+    }
+  }
+
+  /* Disabled: No longer using rexray/ebs.
+  dynamic "volume" {
+    for_each = var.volumes
+    content {
+      name = volume.value.name
+
+      docker_volume_configuration {
+        driver        = "rexray/ebs"
+        scope         = "shared"
+        autoprovision = true
+      }
+    }
+  }
+  */
+
   container_definitions = jsonencode([
     {
       name        = var.name
@@ -58,7 +81,7 @@ resource "aws_ecs_task_definition" "task_def" {
       cpu         = var.container_cpu
       memory      = var.container_mem
       command     = var.command == [] ? null : var.command
-      mountPoints = []
+      mountPoints = var.mount_points == [] ? [] : var.mount_points
       volumesFrom = []
       portMappings = var.service_port == 0 ? [] : [{
         containerPort = var.service_port

--- a/terraform/modules/ecs_service/variables.tf
+++ b/terraform/modules/ecs_service/variables.tf
@@ -53,6 +53,33 @@ variable "command" {
   default     = []
 }
 
+variable "mount_points" {
+  type = list(object({
+    containerPath = string
+    sourceVolume  = string
+  }))
+  description = "A list of volumes to be mounted in the container."
+  default     = []
+}
+
+variable "placement_constraints" {
+  type = list(object({
+    type       = string
+    expression = string
+  }))
+  description = "A list of constraints for task placement."
+  default     = []
+}
+
+variable "volumes" {
+  type = list(object({
+    name      = string
+    host_path = string
+  }))
+  description = "A list of volumes to attach to the task."
+  default     = []
+}
+
 variable "service_port" {
   type        = number
   description = "The TCP port to expose via `portMapping` for this service. Disabled by default."


### PR DESCRIPTION
## Summary

I partially implemented Postgres on ECS, but the `rexray/ebs` and `portworx` Docker volume plugins haven't been updated since 2019, which has me reconsidering RDS.

Since I ended up doing part of the work, and adjusting our Terraform modules to support more features, I've included that cleanup in this PR as well.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Disables the Postgres ECS service (still using RDS)
- Adds support for volumes, mount points, and placement constraints for ECS services
- Adds a disabled IAM policy which allows EC2 instances to manage EBS volumes
- Fixes whitespace in IAM policies

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
