### PR TITLE
Switches back to Redis via ElastiCache for now

### DIFF
--- a/terraform/staging/alarms.tf
+++ b/terraform/staging/alarms.tf
@@ -23,6 +23,14 @@ module "ecs_alarms" {
   alarm_actions = [module.email_sns_topic.topic_arn]
 }
 
+module "redis_alarms" {
+  source        = "../modules/alarms/elasticache"
+  cluster_id    = "duelyst-staging"
+  node_id       = "0001"
+  instance_type = module.redis.instance_type
+  alarm_actions = [module.email_sns_topic.topic_arn]
+}
+
 module "postgres_alarms" {
   source        = "../modules/alarms/rds"
   database_id   = "duelyst-staging"

--- a/terraform/staging/discovery.tf
+++ b/terraform/staging/discovery.tf
@@ -10,3 +10,10 @@ module "cloudmap_service_redis" {
   namespace_id   = module.cloudmap_namespace.id
   namespace_name = module.cloudmap_namespace.name
 }
+
+module "cloudmap_service_postgres" {
+  source         = "../modules/cloudmap_service"
+  name           = "postgres"
+  namespace_id   = module.cloudmap_namespace.id
+  namespace_name = module.cloudmap_namespace.name
+}

--- a/terraform/staging/discovery.tf
+++ b/terraform/staging/discovery.tf
@@ -1,3 +1,4 @@
+/* Disabled: Not running Redis or Postgres in ECS currently.
 module "cloudmap_namespace" {
   source = "../modules/cloudmap_namespace"
   name   = "duelyst.local"
@@ -17,3 +18,4 @@ module "cloudmap_service_postgres" {
   namespace_id   = module.cloudmap_namespace.id
   namespace_name = module.cloudmap_namespace.name
 }
+*/

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -171,7 +171,6 @@ module "ecs_service_redis" {
   ]
 }
 
-/* Disabled: Using RDS for now.
 module "ecs_service_postgres" {
   source               = "../modules/ecs_service"
   name                 = "postgres"
@@ -180,7 +179,7 @@ module "ecs_service_postgres" {
   task_role            = module.ecs_cluster.task_role
   image_name           = "public.ecr.aws/docker/library/postgres"
   deployed_version     = "13"
-  container_count      = 1
+  container_count      = 0
   container_mem        = 450
   service_port         = 5432
   cloudmap_service_arn = module.cloudmap_service_postgres.service_arn
@@ -210,4 +209,3 @@ module "ecs_service_postgres" {
     { name = "POSTGRES_PASSWORD", valueFrom = "/duelyst/staging/postgres/password" }
   ]
 }
-*/

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -35,6 +35,8 @@ module "ecs_service_api" {
 
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
+    # Use module.redis.instance_dns for ElastiCache.
+    # Use module.cloudmap_service_redis.dns_name for Redis on ECS.
     { name = "REDIS_HOST", value = module.cloudmap_service_redis.dns_name },
     { name = "FIREBASE_URL", value = var.firebase_url },
     { name = "FIREBASE_PROJECT_ID", value = var.firebase_project },

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -35,9 +35,7 @@ module "ecs_service_api" {
 
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
-    # Use module.redis.instance_dns for ElastiCache.
-    # Use module.cloudmap_service_redis.dns_name for Redis on ECS.
-    { name = "REDIS_HOST", value = module.cloudmap_service_redis.dns_name },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
     { name = "FIREBASE_URL", value = var.firebase_url },
     { name = "FIREBASE_PROJECT_ID", value = var.firebase_project },
     { name = "CDN_DOMAIN_NAME", value = var.cdn_domain_name },
@@ -69,7 +67,7 @@ module "ecs_service_game" {
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
     { name = "GAME_PORT", value = 8001 },
-    { name = "REDIS_HOST", value = module.cloudmap_service_redis.dns_name },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
     { name = "FIREBASE_URL", value = var.firebase_url }
   ]
 
@@ -93,7 +91,7 @@ module "ecs_service_sp" {
 
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
-    { name = "REDIS_HOST", value = module.cloudmap_service_redis.dns_name },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
     { name = "FIREBASE_URL", value = var.firebase_url }
   ]
 
@@ -115,7 +113,7 @@ module "ecs_service_worker" {
 
   environment_variables = [
     { name = "NODE_ENV", value = "staging" },
-    { name = "REDIS_HOST", value = module.cloudmap_service_redis.dns_name },
+    { name = "REDIS_HOST", value = module.redis.instance_dns },
     { name = "FIREBASE_URL", value = var.firebase_url },
     { name = "FIREBASE_PROJECT_ID", value = var.firebase_project },
     { name = "DEFAULT_GAME_SERVER", value = var.staging_domain_name },
@@ -194,6 +192,7 @@ module "ecs_service_postgres" {
     module.third_subnet.id,
   ]
 
+  /* Disabled: Not using rexray/ebs Docker plugin.
   volumes = [
     { name = "postgres-volume", host_path = "/mnt/postgres-volume" }
   ]
@@ -201,6 +200,7 @@ module "ecs_service_postgres" {
   mount_points = [
     { containerPath = "/var/lib/postgresql/data", sourceVolume = "postgres-volume" }
   ]
+  */
 
   environment_variables = [
     { name = "POSTGRES_USER", value = "duelyst" },

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -9,8 +9,8 @@ module "ecs_cluster" {
   # Increase capacity to allow graceful deployments without stopping live containers.
   min_capacity      = 0
   max_capacity      = 0
-  min_spot_capacity = 3
-  max_spot_capacity = 3
+  min_spot_capacity = 2
+  max_spot_capacity = 2
 
   security_group_ids = [module.internal_security_group.id]
   subnets = [
@@ -156,7 +156,7 @@ module "ecs_service_redis" {
   task_role            = module.ecs_cluster.task_role
   image_name           = "public.ecr.aws/docker/library/redis"
   deployed_version     = "6"
-  container_count      = 1
+  container_count      = 0 # Still using ElastiCache.
   container_mem        = 450
   command              = ["redis-server", "--save", "\"\"", "--appendonly", "no"] # Disable persistence.
   service_port         = 6379
@@ -179,7 +179,7 @@ module "ecs_service_postgres" {
   task_role            = module.ecs_cluster.task_role
   image_name           = "public.ecr.aws/docker/library/postgres"
   deployed_version     = "13"
-  container_count      = 0
+  container_count      = 0 # Still using RDS.
   container_mem        = 450
   service_port         = 5432
   cloudmap_service_arn = module.cloudmap_service_postgres.service_arn

--- a/terraform/staging/ecs.tf
+++ b/terraform/staging/ecs.tf
@@ -149,20 +149,20 @@ module "ecs_service_migrate" {
 }
 
 module "ecs_service_redis" {
-  source               = "../modules/ecs_service"
-  name                 = "redis"
-  cluster              = module.ecs_cluster.id
-  capacity_provider    = module.ecs_cluster.spot_capacity_provider
-  task_role            = module.ecs_cluster.task_role
-  image_name           = "public.ecr.aws/docker/library/redis"
-  deployed_version     = "6"
-  container_count      = 0 # Still using ElastiCache.
-  container_mem        = 450
-  command              = ["redis-server", "--save", "\"\"", "--appendonly", "no"] # Disable persistence.
-  service_port         = 6379
-  cloudmap_service_arn = module.cloudmap_service_redis.service_arn
-  network_mode         = "awsvpc"
-  security_groups      = [module.internal_security_group.id]
+  source            = "../modules/ecs_service"
+  name              = "redis"
+  cluster           = module.ecs_cluster.id
+  capacity_provider = module.ecs_cluster.spot_capacity_provider
+  task_role         = module.ecs_cluster.task_role
+  image_name        = "public.ecr.aws/docker/library/redis"
+  deployed_version  = "6"
+  container_count   = 0 # Still using ElastiCache.
+  container_mem     = 450
+  command           = ["redis-server", "--save", "\"\"", "--appendonly", "no"] # Disable persistence.
+  service_port      = 6379
+  network_mode      = "awsvpc"
+  security_groups   = [module.internal_security_group.id]
+  #cloudmap_service_arn = module.cloudmap_service_redis.service_arn
 
   subnets = [
     module.first_subnet.id,
@@ -172,19 +172,19 @@ module "ecs_service_redis" {
 }
 
 module "ecs_service_postgres" {
-  source               = "../modules/ecs_service"
-  name                 = "postgres"
-  cluster              = module.ecs_cluster.id
-  capacity_provider    = module.ecs_cluster.spot_capacity_provider
-  task_role            = module.ecs_cluster.task_role
-  image_name           = "public.ecr.aws/docker/library/postgres"
-  deployed_version     = "13"
-  container_count      = 0 # Still using RDS.
-  container_mem        = 450
-  service_port         = 5432
-  cloudmap_service_arn = module.cloudmap_service_postgres.service_arn
-  network_mode         = "awsvpc"
-  security_groups      = [module.internal_security_group.id]
+  source            = "../modules/ecs_service"
+  name              = "postgres"
+  cluster           = module.ecs_cluster.id
+  capacity_provider = module.ecs_cluster.spot_capacity_provider
+  task_role         = module.ecs_cluster.task_role
+  image_name        = "public.ecr.aws/docker/library/postgres"
+  deployed_version  = "13"
+  container_count   = 0 # Still using RDS.
+  container_mem     = 450
+  service_port      = 5432
+  network_mode      = "awsvpc"
+  security_groups   = [module.internal_security_group.id]
+  #cloudmap_service_arn = module.cloudmap_service_postgres.service_arn
 
   subnets = [
     module.first_subnet.id,

--- a/terraform/staging/networking.tf
+++ b/terraform/staging/networking.tf
@@ -49,16 +49,18 @@ module "internal_security_group" {
       port        = 3000
       cidr_blocks = ["10.0.0.0/16"]
     },
-    {
-      description = "Allow TCP/5432 from VPC"
-      port        = 5432
-      cidr_blocks = ["10.0.0.0/16"]
-    },
-    {
-      description = "Allow TCP/6379 from VPC"
-      port        = 6379
-      cidr_blocks = ["10.0.0.0/16"]
-    },
+    # Not running Postgres in ECS currently.
+    #{
+    #  description = "Allow TCP/5432 from VPC"
+    #  port        = 5432
+    #  cidr_blocks = ["10.0.0.0/16"]
+    #},
+    # Not running Redis in ECS currently.
+    #{
+    #  description = "Allow TCP/6379 from VPC"
+    #  port        = 6379
+    #  cidr_blocks = ["10.0.0.0/16"]
+    #},
     {
       description = "Allow TCP/8000 from VPC"
       port        = 8000
@@ -69,8 +71,9 @@ module "internal_security_group" {
       port        = 8001
       cidr_blocks = ["10.0.0.0/16"]
     },
+    # Temporary SSH access.
     #{
-    #  description = "Temporary SSH access"
+    #  description = "Allow TCP/22 from public Internet"
     #  port        = 22
     #  cidr_blocks = ["0.0.0.0/0"]
     #}

--- a/terraform/staging/redis.tf
+++ b/terraform/staging/redis.tf
@@ -1,0 +1,6 @@
+module "redis" {
+  source             = "../modules/redis_cache"
+  name               = "duelyst-staging"
+  subnet_ids         = [module.first_subnet.id]
+  security_group_ids = [module.redis_security_group.id]
+}


### PR DESCRIPTION
## Summary

As a result of backing away from the RDS -> Postgres on ECS work, I'm reverting this as well.

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Restores ElastiCache + alarms, switches back to it
- Shuts down Postgres and Redis in ECS, scales down the cluster again
- Removes security group rules for Postgres and Redis
- Disables CloudMap and its associated Hosted Zone

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
