### PR TITLE
Ensure active boss event during worker startup

### DIFF
--- a/worker/jobs/rotate-bosses.coffee
+++ b/worker/jobs/rotate-bosses.coffee
@@ -1,0 +1,61 @@
+###
+Job - Rotate Boss Battles
+###
+DuelystFirebase = require '../../server/lib/duelyst_firebase_module.coffee'
+Logger = require '../../app/common/logger.coffee'
+Cards = require '../../app/sdk/cards/cardsLookup.coffee'
+moment = require 'moment'
+
+BossIds = Object.values(Cards.Boss)
+threeDays = 3 * 24 * 60 * 60 * 1000 # Milliseconds.
+
+###*
+# Job - 'rotate-bosses'
+# @param  {Object} job    Kue job
+# @param  {Function} done   Callback when job is complete
+###
+module.exports = (job, done) ->
+  Logger.module("JOB").debug("[J:#{job.id}] rotate-bosses starting")
+
+  # Get boss events from Firebase.
+  DuelystFirebase.connect().getRootRef().then (rootRef) ->
+    rootRef.child('boss-events').once('value').then((snapshot) ->
+      currentBossEvents = snapshot.val()
+      nextBossId = BossIds[0]
+      now = moment().utc().valueOf()
+
+      # Check for an active boss event.
+      if currentBossEvents? and Object.keys(currentBossEvents).length > 0
+        event = currentBossEvents[Object.keys(currentBossEvents)[0]]
+
+        # If there is an active boss already, do nothing.
+        if now < event["event_end"]
+          Logger.module("JOB").log "rotate-bosses: boss event is already active"
+          return done()
+
+        # Determine the next boss ID.
+        nextBossIndex = BossIds.indexOf(event["boss_id"])+1
+        if nextBossIndex >= BossIds.length
+          nextBossIndex = nextBossIndex - BossIds.length
+        nextBossId = BossIds[nextBossIndex]
+
+      # Create a new boss event.
+      event =
+        'boss-battle':
+          event_id: "boss-battle"
+          boss_id: nextBossId
+          event_start: now
+          event_end: now + threeDays
+          valid_end: now + threeDays
+      DuelystFirebase.connect().getRootRef().then (rootRef) ->
+        rootRef.child('boss-events').set(event, (error) ->
+          if error?
+            Logger.module("JOB").error "rotate-bosses: error: #{error}"
+            return done(error)
+          Logger.module("JOB").log "rotate-bosses: started event for boss #{nextBossId}"
+          return done()
+        )
+    )
+  .catch (error) ->
+    Logger.module("JOB").error "rotate-bosses: error: #{error}"
+    return done(error)

--- a/worker/jobs/rotate-bosses.coffee
+++ b/worker/jobs/rotate-bosses.coffee
@@ -7,7 +7,7 @@ Cards = require '../../app/sdk/cards/cardsLookup.coffee'
 moment = require 'moment'
 
 BossIds = Object.values(Cards.Boss)
-threeDays = 3 * 24 * 60 * 60 * 1000 # Milliseconds.
+oneDay = 24 * 60 * 60 * 1000 # Milliseconds.
 
 ###*
 # Job - 'rotate-bosses'
@@ -45,8 +45,8 @@ module.exports = (job, done) ->
           event_id: "boss-battle"
           boss_id: nextBossId
           event_start: now
-          event_end: now + threeDays
-          valid_end: now + threeDays
+          event_end: now + oneDay
+          valid_end: now + oneDay
       DuelystFirebase.connect().getRootRef().then (rootRef) ->
         rootRef.child('boss-events').set(event, (error) ->
           if error?


### PR DESCRIPTION
## Summary

Closes #227.

Ideally this would run once per hour, but I'm not yet sure how to do that in Kue without an inefficient loop. In the meantime, running on worker startup at least partially automates this.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Adds a `rotate-bosses` job which checks for existing boss events, and adds the subsequent boss event when expired
- Triggers the job once on worker startup

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
