### PR TITLE
Skip invalid bosses

### DIFF
--- a/.github/workflows/lint_coffeescript.yaml
+++ b/.github/workflows/lint_coffeescript.yaml
@@ -6,11 +6,11 @@ on:
     - main
   pull_request:
     paths:
-      - app/**/*.coffee
-      #- cli/**/*.coffee
-      #- scripts/**/*.coffee
-      - server/**/*.coffee
-      - worker/**/*.coffee
+      - app/**.coffee
+      #- cli/**.coffee
+      #- scripts/**.coffee
+      - server/**.coffee
+      - worker/**.coffee
 
 jobs:
   linting:

--- a/.github/workflows/lint_javascript.yaml
+++ b/.github/workflows/lint_javascript.yaml
@@ -8,18 +8,18 @@ on:
     paths:
       - .babelrc
       - .mocharc.js
-      - app/**/*.js
+      - app/**.js
       - bulk-decaffeinate.config.js
-      - cli/**/*.js
-      - config/**/*.js
-      - desktop/**/*.js
-      - gulp/**/*.js
+      - cli/**.js
+      - config/**.js
+      - desktop/**.js
+      - gulp/**.js
       - gulpfile.babel.js
-      #- packages/**/*.js
-      - scripts/**/*.js
-      - server/**/*.js
-      - test/**/*.js
-      - worker/**/*.js
+      #- packages/**.js
+      - scripts/**.js
+      - server/**.js
+      - test/**.js
+      - worker/**.js
 
 jobs:
   linting:

--- a/.github/workflows/lint_terraform.yaml
+++ b/.github/workflows/lint_terraform.yaml
@@ -6,7 +6,7 @@ on:
     - main
   pull_request:
     paths:
-      - terraform/**/*.tf
+      - terraform/**.tf
 
 jobs:
   linting:

--- a/worker/jobs/rotate-bosses.coffee
+++ b/worker/jobs/rotate-bosses.coffee
@@ -6,7 +6,11 @@ Logger = require '../../app/common/logger.coffee'
 Cards = require '../../app/sdk/cards/cardsLookup.coffee'
 moment = require 'moment'
 
+# Collect valid boss IDs.
 BossIds = Object.values(Cards.Boss)
+BrokenBossIds = [200106] # These bosses are missing resources and cause login crashes.
+BossIds = BossIds.filter (id) -> return BrokenBossIds.indexOf(id) == -1
+
 oneDay = 24 * 60 * 60 * 1000 # Milliseconds.
 
 ###*


### PR DESCRIPTION
## Summary

Adds some preliminary code for filtering bosses which are invalid.

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Adds filtering of the `BossIds` array in the `rotate-bosses` worker
- Filters boss `200106`, which is missing resources

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
