### PR TITLE
[Desktop] Enable WebGL hardware acceleration by default

### DIFF
--- a/desktop/desktop.js
+++ b/desktop/desktop.js
@@ -28,6 +28,13 @@ if (argv.inProcessGpu) {
   app.commandLine.appendSwitch('in-process-gpu');
 }
 
+// enable WebGL hardware acceleration by default
+app.commandLine.appendSwitch('enable-accelerated-mjpeg-decode');
+app.commandLine.appendSwitch('enable-accelerated-video');
+app.commandLine.appendSwitch('enable-gpu-rasterization');
+app.commandLine.appendSwitch('enable-native-gpu-memory-buffers');
+app.commandLine.appendSwitch('ignore-gpu-blacklist');
+
 process.on('uncaughtException', (error) => {
   if (error != null && error.message != null) console.log(error.message);
   if (error != null && error.stack != null) console.log(error.stack);


### PR DESCRIPTION
## Summary

Enable WebGL hardware acceleration in the desktop app by default for all platforms. Fixes #248.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Appends several WebGL acceleration flags to the Electron build for improved Linux support

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
