### PR TITLE
Make starter bundle a one time purchase

### DIFF
--- a/app/ui/managers/inventory_manager.js
+++ b/app/ui/managers/inventory_manager.js
@@ -407,7 +407,7 @@ var InventoryManager = Manager.extend({
     }
   },
 
-  buyBoosterPacksWithGold: function (numBoosterPacks, cardSetId) {
+  buyBoosterPacksWithGold: function (numBoosterPacks, cardSetId, sku) {
     if (numBoosterPacks == null || isNaN(numBoosterPacks) || numBoosterPacks <= 0) { numBoosterPacks = 1; }
     if (cardSetId == null) { cardSetId = SDK.CardSet.Core; }
     if (this.walletModel.get('gold_amount') >= numBoosterPacks * ORB_GOLD_COST) {
@@ -416,6 +416,7 @@ var InventoryManager = Manager.extend({
       return new Promise(function (resolve, reject) {
         var request = $.ajax({
           data: JSON.stringify({
+            sku,
             qty: numBoosterPacks,
             card_set_id: cardSetId,
             currency_type: 'soft',

--- a/app/ui/views2/shop/confirm_purchase_dialog.js
+++ b/app/ui/views2/shop/confirm_purchase_dialog.js
@@ -581,7 +581,7 @@ var ConfirmPurchaseDialogView = Backbone.Marionette.ItemView.extend({
         return Promise.reject(new Error('Unpurchaseable set'));
       }
 
-      purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, cardSet);
+      purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, cardSet, sku);
     } else {
       // TODO: Add support for bundles, emotes, etc.
       return Promise.resolve()

--- a/app/ui/views2/shop/premium_purchase_dialog.js
+++ b/app/ui/views2/shop/premium_purchase_dialog.js
@@ -480,13 +480,13 @@ var PremiumPurchaseDialogView = Backbone.Marionette.LayoutView.extend({
 
       // product: individual boosters
       if (sku === 'BOOSTER1_GOLD') {
-        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Core);
+        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Core, sku);
       } else if (sku === 'SHIMZAR_BOOSTER1_GOLD') {
-        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Shimzar);
+        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Shimzar, sku);
       } else if (sku === 'BLOODBORN_BOOSTER1_GOLD') {
-        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Bloodborn);
+        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Bloodborn, sku);
       } else if (sku === 'ANCIENTBONDS_BOOSTER1_GOLD') {
-        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Unity);
+        purchasePromise = InventoryManager.getInstance().buyBoosterPacksWithGold(quantity, SDK.CardSet.Unity, sku);
       }
     }
 

--- a/app/ui/views2/shop/shop_spirit_orbs_collection_view.js
+++ b/app/ui/views2/shop/shop_spirit_orbs_collection_view.js
@@ -96,7 +96,7 @@ var ShopSpiritOrbsCollectionView = Backbone.Marionette.ItemView.extend({
 
       if (packProductSet != null
         && !packProductData.is_purchase_limit_reached
-        && (packProductData.sku !== "STARTERBUNDLE_201604" || !ProfileManager.getInstance().get("has_purchased_starter_bundle"))
+        && (packProductData.sku !== 'STARTERBUNDLE_201604' || !ProfileManager.getInstance().get('has_purchased_starter_bundle'))
       ) {
         packProductSet.packProducts.push(packProductData);
       }

--- a/app/ui/views2/shop/shop_spirit_orbs_collection_view.js
+++ b/app/ui/views2/shop/shop_spirit_orbs_collection_view.js
@@ -96,7 +96,7 @@ var ShopSpiritOrbsCollectionView = Backbone.Marionette.ItemView.extend({
 
       if (packProductSet != null
         && !packProductData.is_purchase_limit_reached
-        // && (packProductData.sku !== "STARTERBUNDLE_201604" || !ProfileManager.getInstance().get("has_purchased_starter_bundle"))
+        && (packProductData.sku !== "STARTERBUNDLE_201604" || !ProfileManager.getInstance().get("has_purchased_starter_bundle"))
       ) {
         packProductSet.packProducts.push(packProductData);
       }

--- a/server/lib/data_access/inventory.coffee
+++ b/server/lib/data_access/inventory.coffee
@@ -874,7 +874,7 @@ class InventoryModule
   # @param  {Number}  cardSetId    card set id to buy booster from
   # @return  {Promise}        Promise that will post BOOSTER PACK ID on completion.
   ###
-  @buyBoosterPacksWithGold: (userId, qty, cardSetId) ->
+  @buyBoosterPacksWithGold: (userId, qty, cardSetId, sku) ->
     unless userId
       Logger.module("InventoryModule").debug "buyBoosterPacksWithGold() -> invalid user ID - #{userId}.".red
       return Promise.reject(new Error("Can not buy booster pack with gold : invalid user ID - #{userId}"))
@@ -917,6 +917,9 @@ class InventoryModule
       .bind this_obj
       .then (userRow)->
 
+        if sku == "STARTERBUNDLE_201604" and userRow.has_purchased_starter_bundle
+          throw new Errors.AlreadyExistsError("Player already purchased the starter bundle.")
+
         # if the user has enough gold
         if userRow.wallet_gold >= total_gold_cost
 
@@ -927,6 +930,7 @@ class InventoryModule
           userUpdateParams =
             wallet_gold:    final_wallet_gold
             wallet_updated_at:   NOW_UTC_MOMENT.toDate()
+            has_purchased_starter_bundle: sku == "STARTERBUNDLE_201604"
 
           knex("users").where('id',userId).update(userUpdateParams).transacting(tx)
 
@@ -954,6 +958,14 @@ class InventoryModule
       .then ()->
         return DuelystFirebase.connect().getRootRef()
       .then (fbRootRef) ->
+
+        
+
+        if sku == "STARTERBUNDLE_201604"
+          FirebasePromises.set(fbRootRef.child("users").child(userId).child("has_purchased_starter_bundle"),true)
+          FirebasePromises.safeTransaction(fbRootRef.child("user-purchase-counts").child(userId).child(sku),(purchaseCountRecord)->
+            return { count: 1 }
+          )
 
         return FirebasePromises.update(fbRootRef.child("user-inventory").child(userId).child("wallet"),{
           gold_amount:@.final_wallet_gold

--- a/server/lib/data_access/inventory.coffee
+++ b/server/lib/data_access/inventory.coffee
@@ -959,8 +959,6 @@ class InventoryModule
         return DuelystFirebase.connect().getRootRef()
       .then (fbRootRef) ->
 
-        
-
         if sku == "STARTERBUNDLE_201604"
           FirebasePromises.set(fbRootRef.child("users").child(userId).child("has_purchased_starter_bundle"),true)
           FirebasePromises.safeTransaction(fbRootRef.child("user-purchase-counts").child(userId).child(sku),(purchaseCountRecord)->

--- a/server/routes/api/me/inventory.coffee
+++ b/server/routes/api/me/inventory.coffee
@@ -111,6 +111,7 @@ router.put "/card_lore_collection/:card_id/read_lore_at", (req, res, next) ->
 router.post "/spirit_orbs", (req, res, next) ->
 
   user_id = req.user.d.id
+  sku = req.body.sku
   qty = req.body.qty
   card_set_id = req.body.card_set_id
   currency_type = req.body.currency_type
@@ -119,7 +120,7 @@ router.post "/spirit_orbs", (req, res, next) ->
 
   if (currency_type == 'soft')
     Logger.module("API").debug "Buying Booster Packs for user #{user_id.blue} with GOLD"
-    InventoryModule.buyBoosterPacksWithGold(user_id, qty, card_set_id)
+    InventoryModule.buyBoosterPacksWithGold(user_id, qty, card_set_id, sku)
     .then (value) ->
       Logger.module("API").debug "COMPLETE Buying Booster Pack with GOLD for user #{user_id.blue}".cyan
       res.status(200).json(value)


### PR DESCRIPTION
Old starter bundle handling code was in the old premium purchase section.
This just moves it to the soft spirit orb purchasing section.
The SKU is passed along as well in order to identify the bundle.

Closes #234

## Summary

Describe your changes here. Remove any inapplicable sections.

**App changes (`app/`, etc.):**
- Allow sending of bundle SKU to server
- Restore code that selectively pushes the Starter Bundle

**Server changes (`config/`, `server/`, `worker/`, etc.):**
- Move Starter Bundle verification from the Premium Purchase section to the Spirit Orb purchase section
- Set purchase count for the spirit orb

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
