### PR TITLE
Wider null check for giftCrateTemplate

### DIFF
--- a/app/sdk/giftCrates/giftCrateFactory.coffee
+++ b/app/sdk/giftCrates/giftCrateFactory.coffee
@@ -220,10 +220,10 @@ class GiftCrateFactory
     @_generateCache()
     giftCrateTemplate = @giftCrateTemplateForType(crateType)
 
-    if giftCrateTemplate == null # No template, so consider unavailable
+    if !giftCrateTemplate? # No template, so consider unavailable
       return false
 
-    if giftCrateTemplate.availableAt == null # If available at is not defined or 0 it is available
+    if !giftCrateTemplate.availableAt? # If available at is not defined or 0 it is available
       return true
 
     return MOMENT_NOW_UTC.add(1, 'hours').isAfter(moment(giftCrateTemplate.availableAt)) # Last, compare available at with now + 1 hour


### PR DESCRIPTION
giftCrateTemplate can undefined and is checked if it === null. 
This is not true, this commit uses a better null check.

Hopefully closes #260

## Summary

Describe your changes here. Remove any inapplicable sections.

**Server changes (`config/`, `server/`, `worker/`, etc.):**
- Better null check for giftCrateTemplate 

## Testing

Have you tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
