### PR TITLE
Avoid disabling deck validation with ALL_CARDS_AVAILABLE

### DIFF
--- a/app/ui/models/deck.js
+++ b/app/ui/models/deck.js
@@ -392,8 +392,7 @@ var DeckModel = Backbone.Model.extend({
     // - any starter deck is valid
     // - each card is already validated as it is added/removed
     var valid = true;
-
-    if (!this.get('isStarter') && !process.env.ALL_CARDS_AVAILABLE) {
+    if (!this.get('isStarter') && !process.env.DISABLE_DECK_VALIDATION) {
       // when deck is in production
       if (needsGeneral) {
         // deck must have a general
@@ -403,7 +402,6 @@ var DeckModel = Backbone.Model.extend({
         valid = false;
       }
     }
-
     this._isValid = valid;
 
     // get searchable content

--- a/config/config.js
+++ b/config/config.js
@@ -295,34 +295,11 @@ const config = convict({
     default: true,
     env: 'ALL_CARDS_AVAILABLE',
   },
-  paypalEnvironmentUrl: {
-    doc: 'Paypal Environment Base URL.',
-    // format: "url",
-    default: 'https://sandbox.paypal.com/',
-  },
-  paypalNvpApi: {
-    username: {
-      doc: 'Paypal NVP API username.',
-      default: '',
-    },
-    password: {
-      doc: 'Paypal NVP API password.',
-      default: '',
-    },
-    signature: {
-      doc: 'Paypal NVP API signature.',
-      default: '',
-    },
-    sandbox: {
-      doc: 'Use NVP API Sandbox?',
-      format: Boolean,
-      default: true,
-    },
-  },
-  mailchimpApiKey: {
-    doc: 'Mailchimp API key',
-    format: String,
-    default: '',
+  disableDeckValidation: {
+    doc: 'Requires decks to contain exactly 40 cards and 1 general.',
+    format: Boolean,
+    default: false,
+    env: 'DISABLE_DECK_VALIDATION',
   },
   recordClientLogs: {
     doc: 'Buffer 500 log lines on the client to be able to submit to server.',


### PR DESCRIPTION
## Summary

Describe your changes here. Remove any inapplicable sections.

**App changes (`app/`, etc.):**

- Replaces `ALL_CARDS_AVAILABLE` flag usage with `DISABLE_DECK_VALIDATION` flag in deck validation code

**Server changes (`config/`, `server/`, `worker/`, etc.):**

- Adds `DISABLE_DECK_VALIDATION` flag
- Removes unused PayPal/Mailchimp flags

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
