### PR TITLE
Fixes misaligned stats text labels in game view.

### DIFF
--- a/app/ui/styles/item/dialogs.scss
+++ b/app/ui/styles/item/dialogs.scss
@@ -165,6 +165,6 @@
 		width: 60.0rem;
 		left: 50%;
 		margin-left: -30.0rem;
-		margin-top: 15.0rem;
+		margin-top: 25.0rem;
 	}
 }

--- a/app/view/nodes/cards/BottomDeckCardNode.js
+++ b/app/view/nodes/cards/BottomDeckCardNode.js
@@ -63,7 +63,7 @@ const BottomDeckCardNode = SdkNode.extend({
 
     // mana token
     this.manaTokenSprite = BaseSprite.create(RSX.icon_mana.img);
-    this.manaTokenSprite.setAnchorPoint(0.5, 0.5);
+    this.manaTokenSprite.setAnchorPoint(0.49, 0.45);
     this.manaTokenSprite.setPosition(cc.p(contentSize.width * 0.5, contentSize.height * 0.5 - 50.0));
     this.manaTokenSprite.setScale(0.65);
 

--- a/app/view/nodes/cards/CardNode.js
+++ b/app/view/nodes/cards/CardNode.js
@@ -187,7 +187,7 @@ var CardNode = SdkNode.extend({
     // mana label
     this.manaLabel = new cc.LabelTTF('', RSX.font_bold.name, 24, cc.size(48, 24), cc.TEXT_ALIGNMENT_CENTER);
     this.manaLabel.setFontFillColor({ r: 0, g: 33, b: 159 });
-    this.manaLabel.setAnchorPoint(0.5, 0.5);
+    this.manaLabel.setAnchorPoint(0.51, 0.65);
     this.manaLabel.setVisible(false);
     this._staticContainerNodeFront.addChild(this.manaLabel, 2);
 
@@ -340,8 +340,8 @@ var CardNode = SdkNode.extend({
       // contained elements relative to center
       this._manaGemSprite.setPosition(-100, cardBackgroundContentSize.height * 0.5 - 20);
       this.manaLabel.setPosition(-100, cardBackgroundContentSize.height * 0.5 - 17);
-      this.atkLabel.setPosition(-61, -28);
-      this.hpLabel.setPosition(59, -28);
+      this.atkLabel.setPosition(-61, -32);
+      this.hpLabel.setPosition(59, -32);
       this.cardNameLabel.setPosition(0.0, 21.0);
       this.cardTypeLabel.setPosition(0.0, 4.0);
       this.factionNameLabel.setPosition(0.0, -150.0);

--- a/app/view/nodes/cards/StatsNode.js
+++ b/app/view/nodes/cards/StatsNode.js
@@ -59,13 +59,13 @@ const StatsNode = EntitySupportNode.extend({
     this.atkLabel = new cc.LabelTTF('', RSX.font_regular.name, CONFIG.OVERLAY_STATS_TEXT_SIZE);
     this.atkLabel.setFontFillColor(cc.color.WHITE);
     this.atkLabel.setHorizontalAlignment(cc.TEXT_ALIGNMENT_CENTER);
-    this.atkLabel.setAnchorPoint(cc.p(0.5, 0.5));
+    this.atkLabel.setAnchorPoint(cc.p(0.5, 0.65));
     this.addChild(this.atkLabel);
 
     this.hpLabel = new cc.LabelTTF('', RSX.font_regular.name, CONFIG.OVERLAY_STATS_TEXT_SIZE);
     this.hpLabel.setFontFillColor(cc.color.WHITE);
     this.hpLabel.setHorizontalAlignment(cc.TEXT_ALIGNMENT_CENTER);
-    this.hpLabel.setAnchorPoint(cc.p(0.5, 0.5));
+    this.hpLabel.setAnchorPoint(cc.p(0.5, 0.65));
     this.addChild(this.hpLabel);
 
     // position stats


### PR DESCRIPTION
## Summary

Minor updates to the placement of some labels so that they are aligned when in the game.

## Before change

![before1](https://github.com/open-duelyst/duelyst/assets/169173538/64035e2a-ae53-4b4c-b352-e95660d1bfb8)
![before2](https://github.com/open-duelyst/duelyst/assets/169173538/077f4d78-03d1-4d3b-8a27-eadc39d0562c)

## After change

![after1](https://github.com/open-duelyst/duelyst/assets/169173538/b587bcce-0b91-4d8d-85dc-e3bef982ee47)
![after2](https://github.com/open-duelyst/duelyst/assets/169173538/f3ab24d0-b029-4d76-88a2-8333d9604193)

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [✔️] Starting backend services locally with `docker compose up` succeeds.
- [✔️] I am able to create a new user and log in locally.
- [✔️] I am able to complete a practice game locally.
- [✔️] I am able to complete a purchase of Orbs, etc.
