### PR TITLE
Update yargs URL to use https

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -9021,7 +9021,7 @@ j2j@0.1.2:
     graceful-fs "^3.0.2"
     q "^1.0.1"
     sandbox "^0.8.6"
-    yargs "git://github.com/boneskull/yargs#nylen"
+    yargs "https://github.com/boneskull/yargs#nylen"
 
 jmespath@0.16.0:
   version "0.16.0"


### PR DESCRIPTION
Updated yargs yarn-lock URL to https:// protocol (git:// is no longer supported)

This addresses issue : https://github.com/open-duelyst/duelyst/issues/298