### PR TITLE
Open URLs in a new Electron window

### DIFF
--- a/app/ui/templates/item/login_menu.hbs
+++ b/app/ui/templates/item/login_menu.hbs
@@ -141,7 +141,7 @@
     </div>
   </div>
   <button class="btn btn-clean btn-clean-primary login">{{localize 'login.login_button_label'}}</button>
-  <div class="utility-links"><a href="https://github.com/open-duelyst/duelyst">OpenDuelyst on Github</a> | <a href="https://discord.gg/HhUWfZ9cxe">OpenDuelyst Discord</a></div>
+  <div class="utility-links"><a href="https://github.com/open-duelyst/duelyst" target=_blank>OpenDuelyst on Github</a> | <a href="https://discord.gg/HhUWfZ9cxe" target=_blank>OpenDuelyst Discord</a></div>
 </div>
 
 <div class="registration-block">


### PR DESCRIPTION
## Summary

Prevents login page URLs from taking over the current window, since Electron has no "back" button. This allows users to close/kill the popup windows in both windowed and full screen modes.

Closes #263

**App changes (`app/`, etc.):**

- Adds `target=_blank` to URLs in the login page, forcing a new window to open

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
