### PR TITLE
Upgrades Node.js from v18 to v24

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -19,7 +19,7 @@ on:
 jobs:
   integration_tests:
     runs-on: ubuntu-latest
-    container: node:18-slim
+    container: node:24-slim
     services:
       redis:
         image: redis:6

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,7 @@
 version: "3.9"
 
 x-base-service: &base
-  image: node:18-slim
+  image: node:24-slim
   entrypoint: sh
   working_dir: /app
   volumes:

--- a/docker/nodejs.Dockerfile
+++ b/docker/nodejs.Dockerfile
@@ -1,5 +1,5 @@
 # Slim images are based on Debian, but with a smaller size footprint.
-FROM node:18-slim
+FROM node:24-slim
 
 # Install bcrypt dependencies and git.
 # TODO: Isolate bcrypt dependencies to API images only.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -26,12 +26,12 @@
 
 To build the code, you will need Node.js, NPM, and Yarn.
 
-For Windows environments, install Volta, Node.js v18, and Yarn v1.
+For Windows environments, install Volta, Node.js v24, and Yarn v1.
 
 For Unix environments:
 ```bash
 curl https://get.volta.sh | bash
-volta install node@18
+volta install node@24
 volta install yarn@1
 ```
 


### PR DESCRIPTION
## Summary

Upgrade our Node.js images from v18 (April 2022) to v24 (May 2025), which will soon be an LTS version. 

This includes several major upgrades:
- https://github.com/nodejs/node/releases/tag/v19.0.0
- https://github.com/nodejs/node/releases/tag/v20.0.0
- https://github.com/nodejs/node/releases/tag/v21.0.0
- https://github.com/nodejs/node/releases/tag/v22.0.0
- https://github.com/nodejs/node/releases/tag/v23.0.0
- https://github.com/nodejs/node/releases/tag/v24.0.0

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Update local images to Node v24

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Update CI images to Node v24

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
