### PR TITLE
Upgrades node-version in CI workflows

### DIFF
--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -39,7 +39,7 @@ jobs:
           node-modules-
 
     - name: install node dependencies
-      run: yarn install --dev
+      run: yarn install
 
     - name: install typescript dependencies
       run: yarn tsc:chroma-js

--- a/.github/workflows/build_app.yaml
+++ b/.github/workflows/build_app.yaml
@@ -26,7 +26,7 @@ jobs:
     - name: install node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
 
     # Caching node_modules saves 50s on builds which don't modify dependencies.
     # Compared to yarn caching, it saves an additional 27 seconds.

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -48,7 +48,7 @@ jobs:
           node-modules-
 
     - name: install node dependencies
-      run: yarn install --dev
+      run: yarn install
 
     - name: run database migrations
       run: yarn migrate:latest

--- a/.github/workflows/lint_coffeescript.yaml
+++ b/.github/workflows/lint_coffeescript.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: install node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
 
     # Caching node_modules saves 50s on builds which don't modify dependencies.
     # Compared to yarn caching, it saves an additional 27 seconds.

--- a/.github/workflows/lint_coffeescript.yaml
+++ b/.github/workflows/lint_coffeescript.yaml
@@ -38,7 +38,7 @@ jobs:
           node-modules-
 
     - name: install node dependencies
-      run: yarn install --dev
+      run: yarn install
 
     - name: compile typescript dependencies
       run: yarn tsc:chroma-js

--- a/.github/workflows/lint_javascript.yaml
+++ b/.github/workflows/lint_javascript.yaml
@@ -34,7 +34,7 @@ jobs:
     - name: install node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
 
     # Caching node_modules saves 50s on builds which don't modify dependencies.
     # Compared to yarn caching, it saves an additional 27 seconds.

--- a/.github/workflows/lint_javascript.yaml
+++ b/.github/workflows/lint_javascript.yaml
@@ -47,7 +47,7 @@ jobs:
           node-modules-
 
     - name: install node dependencies
-      run: yarn install --dev
+      run: yarn install
 
     - name: compile typescript dependencies
       run: yarn tsc:chroma-js

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: install node.js
       uses: actions/setup-node@v3
       with:
-        node-version: 18
+        node-version: 24
 
     # Caching node_modules saves 50s on builds which don't modify dependencies.
     # Compared to yarn caching, it saves an additional 27 seconds.

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -42,7 +42,7 @@ jobs:
           node-modules-
 
     - name: install node dependencies
-      run: yarn install --dev
+      run: yarn install
 
     - name: run unit tests
       run: yarn test:unit

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -86,7 +86,7 @@ will appear in the main menu.
 Now that dependencies are installed, you can build the game code and its
 assets. This step will take a few minutes.
 ```bash
-yarn install --dev
+yarn install
 yarn tsc:chroma-js
 FIREBASE_URL=<your-firebase-url> yarn build
 ```
@@ -101,7 +101,7 @@ with the server code.
 After building the app, the desktop clients can be built separately:
 ```bash
 cd desktop
-yarn install --dev
+yarn install
 # replace <platform> with 'mac', 'windows', 'linux', or 'all'
 yarn build:<platform>
 yarn start:<platform>

--- a/scripts/build_staging_app.sh
+++ b/scripts/build_staging_app.sh
@@ -11,7 +11,7 @@ fi
 
 # Clean and reinstall dependencies.
 rm -rf node_modules
-yarn install --dev || exit 1
+yarn install || exit 1
 
 # Build the game client.
 NODE_ENV=staging yarn build:withallrsx || exit 1

--- a/scripts/rebuild_and_start.sh
+++ b/scripts/rebuild_and_start.sh
@@ -1,7 +1,7 @@
 # Helper scripts for performing a full rebuild before starting the backend.
 
 # Install dependencies.
-yarn install --dev || exit 1
+yarn install || exit 1
 
 # Build the game client.
 if [ -z $FIREBASE_URL ]; then


### PR DESCRIPTION
## Summary

**Infrastructure changes (`.github/`, `terraform/`, etc.):**

- Removes usage of deprecated Yarn argument
- Upgrades node-version in CI workflows

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
