### PR TITLE
Updates `docker-compose.yaml` with various fixes/improvements

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,19 @@
+volumes:
+  app:
+    driver: local
+    driver_opts:
+      type: none
+      device: .
+      o: bind
+  node_modules:
+
 x-base-service: &base
   image: node:24-slim
   entrypoint: sh
   working_dir: /app
   volumes:
-    - .:/app:z
-    - /app/node_modules
+    - app:/app:z
+    - node_modules:/app/node_modules # Keep container packages separate from localdev for Win/Mac support.
 
 services:
   redis:


### PR DESCRIPTION
## Summary

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Removes deprecated `version` parameter from `docker-compose.yaml`
- Adds SELinux context flags (`:z`, `:Z`) to `docker-compose.yaml` to support RHEL/CentOS/Fedora systems
- Declares shared volumes in `docker-compose.yaml` to deduplicate data and increase efficiency

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
