### PR TITLE
Adds more SELinux context flags

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -10,7 +10,7 @@ services:
       POSTGRES_PASSWORD: duelyst
       POSTGRES_DB: duelyst
     volumes:
-      - ./.pgdata:/var/lib/postgresql/data:Z
+      - ./.pgdata:/var/lib/postgresql/data:z
 
   api:
     build:
@@ -19,7 +19,7 @@ services:
     working_dir: /duelyst
     ports: [3000:3000]
     volumes:
-      - ./dist/src:/duelyst/dist/src # Serve frontend via API in localdev.
+      - ./dist/src:/duelyst/dist/src:z # Serve frontend via API in localdev.
     environment:
       FIREBASE_CLIENT_EMAIL: ${FIREBASE_CLIENT_EMAIL}
       FIREBASE_LEGACY_TOKEN: ${FIREBASE_LEGACY_TOKEN}


### PR DESCRIPTION
## Summary

This gets things working on RHEL derivatives again.

**Build changes (`docker/`, `gulp/`, `scripts/`, etc.):**

- Adds more SELinux context flags

## Testing

Have you have tested your changes in the following scenarios?
Feel free to check off scenarios which don't apply.

- [x] Starting backend services locally with `docker compose up` succeeds.
- [x] I am able to create a new user and log in locally.
- [x] I am able to complete a practice game locally.
- [x] I am able to complete a purchase of Orbs, etc.
